### PR TITLE
Audit and correct project documentation

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,10 +23,14 @@ jobs:
         run: uv build --no-sources
 
       - name: Smoke test wheel
-        run: uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
+        run: |
+          uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.whl gmshparser --version
 
       - name: Smoke test source distribution
-        run: uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
+        run: |
+          uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.tar.gz gmshparser --version
 
       - name: Publish distributions to PyPI
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,17 +32,17 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
-      - name: Check formatting of package metadata
+      - name: Check package formatting
         continue-on-error: true
-        run: uv run --no-sync black gmshparser/__init__.py --check
+        run: uv run --no-sync black gmshparser --check
 
-      - name: Check formatting of CLI
+      - name: Check test formatting
         continue-on-error: true
-        run: uv run --no-sync black gmshparser/cli.py --check
+        run: uv run --no-sync black tests --check
 
-      - name: Check formatting of CLI tests
+      - name: Check formatting outside package and tests
         continue-on-error: true
-        run: uv run --no-sync black tests/test_cli.py --check
+        run: uv run --no-sync black . --check --exclude '/(gmshparser|tests)/'
 
       - name: Check all formatting
         run: uv run --no-sync black . --check

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,11 +47,15 @@ jobs:
 
       - name: Smoke test wheel
         if: matrix.python-version == '3.12'
-        run: uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
+        run: |
+          uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.whl gmshparser --version
 
       - name: Smoke test source distribution
         if: matrix.python-version == '3.12'
-        run: uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
+        run: |
+          uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.tar.gz gmshparser --version
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,19 +32,6 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
-      - name: Capture formatting diff
-        if: matrix.python-version == '3.12'
-        run: |
-          uv run --no-sync black gmshparser tests examples
-          git diff -- gmshparser tests examples > black.diff
-
-      - name: Upload formatting diff
-        if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
-        with:
-          name: black-formatting-diff
-          path: black.diff
-
       - name: Check formatting
         run: uv run --no-sync black gmshparser tests examples --check
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
+      - name: Format example for diagnosis
+        if: matrix.python-version == '3.12'
+        run: uv run --no-sync black examples/visualize_quads.py
+
+      - name: Upload formatted example
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: black-formatted-example
+          path: examples/visualize_quads.py
+
       - name: Check formatting
         run: uv run --no-sync black gmshparser tests examples --check
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,17 +32,6 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
-      - name: Format example for diagnosis
-        if: matrix.python-version == '3.12'
-        run: uv run --no-sync black examples/visualize_quads.py
-
-      - name: Upload formatted example
-        if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
-        with:
-          name: black-formatted-example
-          path: examples/visualize_quads.py
-
       - name: Check formatting
         run: uv run --no-sync black gmshparser tests examples --check
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,20 +32,8 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
-      - name: Check package formatting
-        continue-on-error: true
-        run: uv run --no-sync black gmshparser --check
-
-      - name: Check test formatting
-        continue-on-error: true
-        run: uv run --no-sync black tests --check
-
-      - name: Check formatting outside package and tests
-        continue-on-error: true
-        run: uv run --no-sync black . --check --exclude '/(gmshparser|tests)/'
-
-      - name: Check all formatting
-        run: uv run --no-sync black . --check
+      - name: Check formatting
+        run: uv run --no-sync black gmshparser tests examples --check
 
       - name: Lint
         run: uv run --no-sync flake8 gmshparser tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
+      - name: Capture formatting diff
+        if: matrix.python-version == '3.12'
+        run: |
+          uv run --no-sync black gmshparser tests examples
+          git diff -- gmshparser tests examples > black.diff
+
+      - name: Upload formatting diff
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: black-formatting-diff
+          path: black.diff
+
       - name: Check formatting
         run: uv run --no-sync black gmshparser tests examples --check
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,19 @@ jobs:
       - name: Install test and lint dependencies
         run: uv sync --no-default-groups --group test --group lint
 
-      - name: Check formatting
+      - name: Check formatting of package metadata
+        continue-on-error: true
+        run: uv run --no-sync black gmshparser/__init__.py --check
+
+      - name: Check formatting of CLI
+        continue-on-error: true
+        run: uv run --no-sync black gmshparser/cli.py --check
+
+      - name: Check formatting of CLI tests
+        continue-on-error: true
+        run: uv run --no-sync black tests/test_cli.py --check
+
+      - name: Check all formatting
         run: uv run --no-sync black . --check
 
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The repository uses uv and intentionally does not commit dependency lock files.
 git clone https://github.com/ahojukka5/gmshparser.git
 cd gmshparser
 uv sync
-uv run black . --check
+uv run black gmshparser tests examples --check
 uv run flake8 gmshparser tests
 uv run pytest
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gmshparser - parse Gmsh .msh file format
+# gmshparser — parse Gmsh `.msh` files
 
 [![Python CI][gh-ci-img]][gh-ci-url]
 [![codecov][codecov-img]][codecov-url]
@@ -10,227 +10,137 @@
 
 ![gmshparser hero image](docs/hero-image.webp)
 
-Package author: Jukka Aho (@ahojukka5)
+gmshparser is a small, dependency-free Python package for reading **ASCII**
+[Gmsh](https://gmsh.info/) MSH files. It provides a consistent object model for
+nodes, elements, and entities across the supported format versions.
 
-Gmshparser is a small Python package which aims to do only one thing: parse Gmsh
-mesh file format. Package does not have any external dependencies to other
-packages and it aims to be a simple stand-alone solution for a common problem:
-how to import mesh to your favourite research FEM code?
+- **Python:** 3.12 or newer
+- **MSH formats:** 1.0, 2.0, 2.1, 2.2, 4.0, and 4.1
+- **Core dependencies:** none
+- **Scope:** reading meshes; writing and binary MSH files are not supported
 
-- Project source in GitHub: [https://github.com/ahojukka5/gmshparser](https://github.com/ahojukka5/gmshparser)
-- Project documentation: [https://ahojukka5.github.io/gmshparser/](https://ahojukka5.github.io/gmshparser/)
-- Project releases in PyPi: [https://pypi.org/project/gmshparser](https://pypi.org/project/gmshparser)
+Project links:
 
-## Supported Gmsh MSH file formats
+- [Documentation](https://ahojukka5.github.io/gmshparser/)
+- [PyPI package](https://pypi.org/project/gmshparser)
+- [Issue tracker](https://github.com/ahojukka5/gmshparser/issues)
 
-gmshparser supports multiple versions of the Gmsh MSH file format:
+## Installation
 
-- **MSH 1.0**: Legacy format using `$NOD/$ENDNOD` and `$ELM/$ENDELM` sections
-- **MSH 2.0, 2.1, 2.2**: Standard format with `$MeshFormat`, `$Nodes`, and `$Elements` sections
-- **MSH 4.0, 4.1**: Modern format with entity-based organization using `$Entities` section
+Install the stable release with uv:
 
-The parser automatically detects the file format version and uses the appropriate
-parser for that version, so you don't need to worry about which version you're
-working with.
+```bash
+uv add gmshparser
+```
 
-## Installing package
-
-To install the most recent package from Python Package Index (PyPi), use git:
+or with pip:
 
 ```bash
 pip install gmshparser
 ```
 
-To install the development version, you can install the package directly from
-the GitHub:
+Install the current development version directly from GitHub:
 
 ```bash
-pip install git+git://github.com/ahojukka5/gmshparser.git
+uv add "gmshparser @ git+https://github.com/ahojukka5/gmshparser.git"
 ```
 
-## Using application programming interface
-
-To read mesh into `Mesh` object, use command `parse`. It takes a filename and
-parses the file with the set of parsers, defined in `DEFAULT_PARSERS` (see
-developing package section for more info..!)
+## Python API
 
 ```python
 import gmshparser
-mesh = gmshparser.parse("data/testmesh.msh")
+
+mesh = gmshparser.parse("mesh.msh")
 print(mesh)
 ```
 
-```text
-Mesh name: data/testmesh.msh
-Mesh version: 4.1
-Number of nodes: 6
-Minimum node tag: 1
-Maximum node tag: 6
-Number of node entities: 1
-Number of elements: 2
-Minimum element tag: 1
-Maximum element tag: 2
-Number of element entities: 1
-```
-
-After reading the model, you can querying your data form `mesh` object. For
-example, to extract all nodes from the model:
+Iterate over nodes:
 
 ```python
 for entity in mesh.get_node_entities():
     for node in entity.get_nodes():
-        nid = node.get_tag()
-        ncoords = node.get_coordinates()
-        print("Node id = %s, node coordinates = %s" % (nid, ncoords))
+        print(node.get_tag(), node.get_coordinates())
 ```
 
-```text
-Node id = 1, node coordinates = (0.0, 0.0, 0.0)
-Node id = 2, node coordinates = (1.0, 0.0, 0.0)
-Node id = 3, node coordinates = (1.0, 1.0, 0.0)
-Node id = 4, node coordinates = (0.0, 1.0, 0.0)
-Node id = 5, node coordinates = (2.0, 0.0, 0.0)
-Node id = 6, node coordinates = (2.0, 1.0, 0.0)
-```
-
-Extract all elements from the model:
+Iterate over elements:
 
 ```python
 for entity in mesh.get_element_entities():
-    eltype = entity.get_element_type()
-    print("Element type: %s" % eltype)
+    element_type = entity.get_element_type()
     for element in entity.get_elements():
-        elid = element.get_tag()
-        elcon = element.get_connectivity()
-        print("Element id = %s, connectivity = %s" % (elid, elcon))
+        print(element.get_tag(), element_type, element.get_connectivity())
 ```
 
-```text
-Element type: 3
-Element id = 1, connectivity = [1, 2, 3, 4]
-Element id = 2, connectivity = [2, 5, 6, 3]
-```
+The parser detects the MSH version automatically. See the
+[Basic Usage guide](https://ahojukka5.github.io/gmshparser/user-guide/basic-usage/)
+for the complete data-access examples.
 
-If you are writing your FEM stuff with Python, then you have access to the all
-relevant properties of the model using `mesh` object. For further information on
-how to access nodes, elements, physical groups, and other things what Gmsh
-provides, take a look of [documentation](https://ahojukka5.github.io/gmshparser/).
+## Command-line interface
 
-### Using command line interface
-
-gmshparser can also be useful even if you don't make FEM code in Python. The
-above loops used to extract nodes and elements are actually so common, that you
-can use them from the command line. This way you can print nodes and elements in
-a simpler format with command-line tools, making it easier to read an element
-mesh with C ++ or Fortran, for example. To extract nodes:
+The installed `gmshparser` command can print a mesh summary, nodes, or elements:
 
 ```bash
-jukka@jukka-XPS-13-9380:~$ gmshparser data/testmesh.msh nodes
+gmshparser mesh.msh info
+gmshparser mesh.msh nodes
+gmshparser mesh.msh elements
+gmshparser --version
 ```
 
-```text
-6
-1 0.000000 0.000000 0.000000
-2 1.000000 0.000000 0.000000
-3 1.000000 1.000000 0.000000
-4 0.000000 1.000000 0.000000
-5 2.000000 0.000000 0.000000
-6 2.000000 1.000000 0.000000
-```
+`nodes` output begins with the node count, followed by
+`node_id x y z`. `elements` output begins with the element count, followed by
+`element_id element_type connectivity...`.
 
-To extract elements, use choice `elements`. The first line is having the total
-number of elements, and the rest of the lines are in format `element_id
-element_type element_connectivity`. The length of the line naturally depends on
-how many nodes the element is having.
+## Visualization helpers
 
-```bash
-jukka@jukka-XPS-13-9380:~$ gmshparser data/testmesh.msh elements
-```
-
-```text
-2
-1 3 1 2 3 4
-2 3 2 5 6 3
-```
-
-### Visualizing meshes using gmshparser and matplotlib
-
-The intention of the package is not to visualize meshes. But as it is a quite
-common task to visualize 2-dimensional triangluar meshes in acedemic papers,
-lecture notes, and things like that, it can be done easily using gmshparser and
-matplotlib. There's a helper function `gmshparser.helpers.get_triangles`, which
-returns a tuple `(X, Y, T)` which can then be passed to matplotlib to get a mesh
-plot:
+Matplotlib is optional. The triangle helper returns zero-based connectivity
+suitable for `matplotlib.triplot`:
 
 ```python
 import gmshparser
-mesh = gmshparser.parse("data/example_mesh.msh")
-X, Y, T = gmshparser.helpers.get_triangles(mesh)
+import matplotlib.pyplot as plt
 
-import matplotlib.pylab as plt
-plt.figure()
-plt.triplot(X, Y, T, color='black')
-plt.axis('equal')
-plt.axis('off')
-plt.tight_layout()
-plt.savefig('docs/example_mesh.svg')
+mesh = gmshparser.parse("mesh.msh")
+X, Y, triangles = gmshparser.helpers.get_triangles(mesh)
+plt.triplot(X, Y, triangles)
+plt.axis("equal")
+plt.show()
 ```
 
-![Example mesh visualization](docs/example_mesh.svg)
+Install the optional dependency separately:
 
-## Developing package
-
-gmshparser is written such a way, that it's easy to define your own parsers
-which are responsible for parsing some section, starting with `$SectionName` and
-ending with `$EndSectionName`. For example, a parser which is responsible to
-parse `MeshFormat` setion is `MainFormatParser` and it is defined with the
-following code:
-
-```python
-class MeshFormatParser(AbstractParser):
-
-    @staticmethod
-    def get_section_name():
-        return "$MeshFormat"
-
-    @staticmethod
-    def parse(mesh: Mesh, io: TextIO) -> None:
-        s = io.readline().strip().split(" ")
-        mesh.set_version(float(s[0]))
-        mesh.set_ascii(int(s[1]) == 0)
-        mesh.set_precision(int(s[2]))
+```bash
+uv add matplotlib
 ```
 
-All the active parsers used in parsing are then appended to the list of parsers
-in [MainParser](gmshparser/main_parser.py), from where they are called when an
-appropriate `get_section_name()` is found from file considered to be parsed. The
-`MainParser` itself is then called in `parse` to get things done:
+## Development
 
-```python
-def parse(filename: str) -> Mesh:
-    """Parse Gmsh .msh file and return `Mesh` object."""
-    mesh = Mesh()
-    mesh.set_name(filename)
-    parser = MainParser()
-    with open(filename, "r") as io:
-        parser.parse(mesh, io)
-    return mesh
+The repository uses uv and intentionally does not commit dependency lock files.
+
+```bash
+git clone https://github.com/ahojukka5/gmshparser.git
+cd gmshparser
+uv sync
+uv run black . --check
+uv run flake8 gmshparser tests
+uv run pytest
 ```
 
-If you want to learn how to write your own parser, you can e.g. take of look of
-[NodesParser](gmshparser/nodes_parser.py) which is responsible for parsing nodes
-and [ElementsParser](gmshparser/elements_parser.py) which is responsible for
-parsing elements, to get an idea how things are implemented.
+Build the documentation with:
 
-## Contributing to project
+```bash
+uv sync --group docs
+uv run mkdocs build
+```
 
-Like in all other open source projects, contributions are always welcome to this
-project too! If you have some great ideas how to make this package better,
-feature requests etc., you can open an issue on gmshparser's [issue
-tracker][issues] or contact me (<ahojukka5@gmail.com>) directly.
+See the [Contributing guide](https://ahojukka5.github.io/gmshparser/developer-guide/contributing/)
+for dependency groups and the release workflow.
 
-[gh-ci-img]: https://github.com/ahojukka5/gmshparser/workflows/Python%20CI/badge.svg
-[gh-ci-url]: https://github.com/ahojukka5/gmshparser/actions
+## License
+
+gmshparser is released under the MIT License.
+
+[gh-ci-img]: https://github.com/ahojukka5/gmshparser/actions/workflows/python.yml/badge.svg
+[gh-ci-url]: https://github.com/ahojukka5/gmshparser/actions/workflows/python.yml
 [codecov-img]: https://codecov.io/gh/ahojukka5/gmshparser/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/ahojukka5/gmshparser
 [pypi-img]: https://img.shields.io/pypi/v/gmshparser
@@ -242,4 +152,3 @@ tracker][issues] or contact me (<ahojukka5@gmail.com>) directly.
 [python-img]: https://img.shields.io/pypi/pyversions/gmshparser
 [license-img]: https://img.shields.io/github/license/ahojukka5/gmshparser
 [license-url]: https://github.com/ahojukka5/gmshparser/blob/master/LICENSE
-[issues]: https://github.com/ahojukka5/gmshparser/issues

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,73 +1,81 @@
 # Changelog
 
-All notable changes to gmshparser will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Notable user-visible changes to gmshparser are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project uses
+semantic versioning.
 
 ## [Unreleased]
 
 ### Added
 
-- MkDocs documentation system with Material theme
-- Comprehensive user guide and developer guide
-- API reference with mkdocstrings
-- Test data organization in `testdata/` directory
-- Git LFS support for large test files
-- Quad visualization helpers (`get_quads`, `get_elements_2d`)
+- PEP 621 console-script metadata for the installed `gmshparser` command
+- `gmshparser --version` support
+- wheel and source-distribution smoke tests for the installed CLI
 
 ### Changed
 
-- Migrated documentation from RST to Markdown
-- Organized test data into `testdata/simple/`, `testdata/complex/`, `testdata/large/`
-- Updated dev dependencies: black 24.x, flake8 7.x, matplotlib 3.10
+- corrected README, user-guide, API, architecture, testing, and test-data
+  documentation to match the current implementation
+- documented Python 3.12+, ASCII-only parsing, version-specific parser routing,
+  and the actual helper return values
+- pointed MkDocs site metadata and badges to GitHub Pages
+- replaced stale exact test-count and coverage claims with links to CI and
+  Codecov as the authoritative status
 
-### Removed
+### Fixed
 
-- Old RST documentation files
-- setup.py (Poetry-only now)
-- data/ directory (moved to testdata/)
+- synchronized `gmshparser.__version__` with package version 0.3.1
+- restored the packaged CLI entry point in `pyproject.toml`
+- removed incorrect claims that binary MSH files, complete physical-group
+  metadata, or Git LFS are currently supported
+
+## [0.3.1]
+
+### Changed
+
+- migrated project builds and development workflows from Poetry to uv and
+  `uv_build`
+- raised the supported Python requirement to 3.12 or newer
+- updated CI to test Python 3.12, 3.13, and 3.14
+- grouped development dependencies with PEP 735 dependency groups
+- intentionally stopped committing dependency lock files
+- modernized GitHub Actions and package build smoke tests
+
+### Documentation
+
+- added the MkDocs Material documentation site
+- organized user, developer, API, and test-data documentation
+- added triangle, quadrilateral, and mixed-2D visualization guidance
 
 ## [0.2.0] - 2025-11-16
 
 ### Added
 
-- Support for MSH 1.0 format (legacy `$NOD`/`$ELM` sections)
-- Support for MSH 2.0, 2.1, 2.2 formats
-- Support for MSH 4.0, 4.1 formats
-- Automatic version detection
-- Version-specific parser routing
-- `VersionManager` for version validation
-- V1 parsers (`NodesParserV1`, `ElementsParserV1`)
-- V2 parsers (`NodesParserV2`, `ElementsParserV2`)
-- Comprehensive test suite (34 tests, 97% coverage)
-- Test files for all supported versions
-- Quad visualization support
-- Helper functions: `get_quads()`, `get_elements_2d()`
-
-### Changed
-
-- Updated to Python 3.8.1+ requirement
-- Upgraded pytest to 8.0+
-- Improved error messages
+- MSH 1.0 support for legacy `$NOD` and `$ELM` sections
+- MSH 2.0, 2.1, and 2.2 node and element parsing
+- MSH 4.0 and 4.1 node and element parsing
+- automatic version detection and version-specific parser routing
+- `VersionManager`, V1 parsers, and V2 parsers
+- quadrilateral and mixed-2D helper functions
+- version-specific test fixtures
 
 ### Fixed
 
 - MSH 1.0 parsing compatibility
-- Version detection for legacy formats
+- version detection for legacy formats
 
-## [0.1.0] - 2020-XX-XX
+## [0.1.0]
 
 ### Added
 
-- Initial release
-- MSH 4.1 format support
-- Basic mesh parsing functionality
-- Command-line interface
-- Triangle visualization helpers
+- initial mesh parser
+- MSH 4.1 parsing
+- Python API
+- command-line helpers
+- triangle visualization helper
 
 ## Links
 
-- [PyPI Releases](https://pypi.org/project/gmshparser/#history)
-- [GitHub Releases](https://github.com/ahojukka5/gmshparser/releases)
-- [GitHub Commits](https://github.com/ahojukka5/gmshparser/commits)
+- [PyPI releases](https://pypi.org/project/gmshparser/#history)
+- [GitHub releases](https://github.com/ahojukka5/gmshparser/releases)
+- [GitHub commits](https://github.com/ahojukka5/gmshparser/commits)

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -1,85 +1,87 @@
 # Helpers API
 
-Utility functions for common mesh operations.
-
-## get_triangles()
-
-Extract triangular elements from mesh for plotting.
+## `get_triangles()`
 
 ::: gmshparser.helpers.get_triangles
     options:
       show_source: true
       heading_level: 3
 
-**Example:**
+Returns `(X, Y, triangles)`. Triangle connectivity contains zero-based indices
+into `X` and `Y`.
 
 ```python
-import gmshparser
 import matplotlib.pyplot as plt
 from gmshparser.helpers import get_triangles
 
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-plt.triplot(X, Y, T)
-plt.show()
+X, Y, triangles = get_triangles(mesh)
+plt.triplot(X, Y, triangles)
 ```
 
-## get_quads()
+Only two-dimensional Gmsh type-2 elements are included.
 
-Extract quadrilateral elements from mesh.
+## `get_quads()`
 
 ::: gmshparser.helpers.get_quads
     options:
       show_source: true
       heading_level: 3
 
-**Example:**
+Returns `(X, Y, quads)`. Quad connectivity contains zero-based indices into `X`
+and `Y`.
 
 ```python
+from matplotlib.patches import Polygon
 from gmshparser.helpers import get_quads
 
-mesh = gmshparser.parse("quad_mesh.msh")
-X, Y, Q = get_quads(mesh)
-
-# Plot quads
-for quad in Q:
-    x = [X[n-1] for n in quad] + [X[quad[0]-1]]
-    y = [Y[n-1] for n in quad] + [Y[quad[0]-1]]
-    plt.plot(x, y, 'k-')
+X, Y, quads = get_quads(mesh)
+for quad in quads:
+    coordinates = [(X[index], Y[index]) for index in quad]
+    axes.add_patch(Polygon(coordinates, fill=False))
 ```
 
-## get_elements_2d()
+Only two-dimensional Gmsh type-3 elements are included.
 
-Extract all 2D elements (triangles and quads).
+## `get_elements_2d()`
 
 ::: gmshparser.helpers.get_elements_2d
     options:
       show_source: true
       heading_level: 3
 
-**Example:**
+Returns a dictionary rather than coordinate arrays:
 
 ```python
 from gmshparser.helpers import get_elements_2d
 
-mesh = gmshparser.parse("mixed_mesh.msh")
-X, Y, triangles, quads = get_elements_2d(mesh)
+data = get_elements_2d(mesh)
 
-print(f"Found {len(triangles)} triangles and {len(quads)} quads")
+nodes = data["nodes"]
+triangles = data["triangles"]
+quads = data["quads"]
+node_ids = data["node_ids"]
 ```
 
-## Utility Functions
+- `nodes` maps original Gmsh node tags to `(x, y)` coordinates.
+- `triangles` and `quads` preserve original node tags in their connectivity.
+- `node_ids` is the sorted list of referenced node tags.
 
-### parse_ints()
+Do not unpack this helper as `(X, Y, triangles, quads)` and do not apply a
+`-1` offset to its node tags.
 
-Parse space-separated integers from string.
+## Line parsers
 
-### parse_floats()
+### `parse_ints()`
 
-Parse space-separated floats from string.
+Reads one line from a text stream and returns its space-separated values as
+integers.
 
-## See Also
+### `parse_floats()`
 
-- [Visualization Guide](../user-guide/visualization.md)
+Reads one line from a text stream and returns its space-separated values as
+floating-point numbers.
+
+## See also
+
+- [Visualization](../user-guide/visualization.md)
 - [Basic Usage](../user-guide/basic-usage.md)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,12 +1,8 @@
 # API Reference
 
-gmshparser provides a simple, clean API for parsing Gmsh mesh files.
+## Package entry points
 
-## Main Functions
-
-### parse()
-
-Parse a Gmsh mesh file and return a Mesh object.
+### `gmshparser.parse()`
 
 ```python
 import gmshparser
@@ -14,82 +10,69 @@ import gmshparser
 mesh = gmshparser.parse("mesh.msh")
 ```
 
-**Parameters:**
+`parse()` accepts a filename and returns a populated `Mesh`. Supported ASCII MSH
+versions are detected automatically.
 
-- `filename` (str): Path to the `.msh` file
+Typical exceptions include `FileNotFoundError` for a missing file and
+`ValueError` for unsupported version metadata. Malformed section contents may
+raise conversion or parsing exceptions from the relevant parser.
 
-**Returns:**
-
-- `Mesh`: Parsed mesh object
-
-**Raises:**
-
-- `FileNotFoundError`: If file doesn't exist
-- `ValueError`: If file format is unsupported or invalid
-
-## Core Classes
-
-### Mesh
-
-The main mesh container class.
-
-For detailed API, see [Mesh API](mesh.md).
-
-### Node & NodeEntity
-
-Classes for node data organization.
-
-### Element & ElementEntity
-
-Classes for element data organization.
-
-### Parsers
-
-Parser classes for different mesh sections.
-
-See [Parsers API](parsers.md) for details.
-
-## Helper Functions
-
-Utility functions for common mesh operations.
-
-See [Helpers API](helpers.md) for details.
-
-## Quick Reference
+### Package metadata
 
 ```python
 import gmshparser
 
-# Parse mesh
-mesh = gmshparser.parse("mesh.msh")
+print(gmshparser.__version__)
+```
 
-# Get mesh info
+## Data model
+
+- [`Mesh`](mesh.md) stores format metadata, counts, tag ranges, and entity lists.
+- `NodeEntity` groups `Node` objects.
+- `ElementEntity` groups `Element` objects with a shared Gmsh element type.
+- [`MainParser` and section parsers](parsers.md) populate the model.
+
+## Common operations
+
+```python
 mesh.get_version()
+mesh.is_ascii()
 mesh.get_number_of_nodes()
 mesh.get_number_of_elements()
-
-# Access nodes
-for entity in mesh.get_node_entities():
-    for node in entity.get_nodes():
-        node.get_tag()
-        node.get_coordinates()
-
-# Access elements
-for entity in mesh.get_element_entities():
-    for element in entity.get_elements():
-        element.get_tag()
-        element.get_connectivity()
-
-# Helper functions
-from gmshparser.helpers import get_triangles, get_quads, get_elements_2d
-
-X, Y, T = get_triangles(mesh)
-X, Y, Q = get_quads(mesh)
-X, Y, triangles, quads = get_elements_2d(mesh)
 ```
 
-## Next Steps
+Iterate over nodes:
 
-- [Mesh API](mesh.md) - Complete Mesh class reference
-- [Parsers API](parsers.md) - Parser classes
-- [Helpers API](helpers.md) - Utility functions
+```python
+for entity in mesh.get_node_entities():
+    for node in entity.get_nodes():
+        node_id = node.get_tag()
+        coordinates = node.get_coordinates()
+```
+
+Iterate over elements:
+
+```python
+for entity in mesh.get_element_entities():
+    element_type = entity.get_element_type()
+    for element in entity.get_elements():
+        element_id = element.get_tag()
+        connectivity = element.get_connectivity()
+```
+
+## Helpers
+
+```python
+from gmshparser.helpers import get_elements_2d, get_quads, get_triangles
+
+X, Y, triangles = get_triangles(mesh)
+X, Y, quads = get_quads(mesh)
+mixed = get_elements_2d(mesh)
+```
+
+`get_triangles()` and `get_quads()` return zero-based connectivity into their
+coordinate arrays. `get_elements_2d()` returns a dictionary with `nodes`,
+`triangles`, `quads`, and `node_ids`, preserving original node tags in the
+connectivity lists.
+
+See [Helpers API](helpers.md) for examples.

--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -1,46 +1,73 @@
 # Parsers API
 
-## AbstractParser
-
-Base class for all parsers.
+## `AbstractParser`
 
 ::: gmshparser.abstract_parser.AbstractParser
     options:
       show_source: true
       heading_level: 3
 
-## MeshFormatParser
+Section parsers expose a section name and a static `parse(mesh, io)` method.
 
-Parses `$MeshFormat` section.
-
-## NodesParser
-
-Parses `$Nodes` section (MSH 2.x and 4.x).
-
-## ElementsParser
-
-Parses `$Elements` section (MSH 2.x and 4.x).
-
-## V1 Parsers
-
-### NodesParserV1
-
-Parses `$NOD` section (MSH 1.0).
-
-### ElementsParserV1
-
-Parses `$ELM` section (MSH 1.0).
-
-## MainParser
-
-Coordinates all parsers and handles version detection.
+## `MainParser`
 
 ::: gmshparser.main_parser.MainParser
     options:
       show_source: true
       heading_level: 3
 
-## See Also
+`MainParser` detects the MSH version and selects one of the version-specific
+parser registries.
 
-- [Writing Custom Parsers](../developer-guide/writing-parsers.md)
-- [Architecture](../developer-guide/architecture.md)
+## Format metadata
+
+### `MeshFormatParser`
+
+Parses `$MeshFormat`, validates the version, and records the ASCII flag and data
+precision. MSH 1.0 does not contain this section.
+
+## MSH 1.0 parsers
+
+### `NodesParserV1`
+
+Parses the legacy `$NOD` section.
+
+### `ElementsParserV1`
+
+Parses the legacy `$ELM` section.
+
+## MSH 2.x parsers
+
+### `NodesParserV2`
+
+Parses the flat `$Nodes` layout used by MSH 2.0, 2.1, and 2.2.
+
+### `ElementsParserV2`
+
+Parses the flat `$Elements` layout used by MSH 2.0, 2.1, and 2.2. It groups
+records into `ElementEntity` objects using the elementary entity tag when
+available. The complete MSH 2.x element-tag list is not exposed by the current
+model.
+
+## MSH 4.x parsers
+
+### `NodesParser`
+
+Parses the entity-block `$Nodes` layout used by MSH 4.0 and 4.1.
+
+### `ElementsParser`
+
+Parses the entity-block `$Elements` layout used by MSH 4.0 and 4.1.
+
+## Parser registries
+
+The default registries are defined in `gmshparser.main_parser`:
+
+```python
+DEFAULT_PARSERS_V1
+DEFAULT_PARSERS_V2
+DEFAULT_PARSERS_V4
+```
+
+See [Writing Parsers](../developer-guide/writing-parsers.md) before adding or
+registering a new section parser.

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,417 +1,97 @@
 # Architecture
 
-This document explains gmshparser's internal architecture and design decisions.
+gmshparser is a read-only parser built around a shared mesh model and separate
+section parsers for the supported MSH version families.
 
-## Design Philosophy
+## Parsing flow
 
-gmshparser follows these principles:
+`gmshparser.parse(filename)` creates a `Mesh`, opens the file in text mode, and
+calls `MainParser.parse(mesh, stream)`. The populated `Mesh` is then returned.
+Because files are opened as text, the current implementation supports ASCII MSH
+files only.
 
-1. **Single responsibility**: Parse Gmsh mesh files, nothing more
-2. **Zero dependencies**: Pure Python, no external dependencies
-3. **Extensibility**: Easy to add new parsers for new sections
-4. **Version agnostic**: Same API regardless of MSH version
-5. **Test-driven**: 100% test coverage goal
-
-## System Overview
-
-```
-┌─────────────┐
-│  User Code  │
-└──────┬──────┘
-       │ gmshparser.parse("mesh.msh")
-       ▼
-┌─────────────┐
-│ MainParser  │ ◄─── Coordinates parsing
-└──────┬──────┘
-       │ Detects version
-       ├─► MSH 1.0 → V1 Parsers
-       ├─► MSH 2.x → V2 Parsers
-       └─► MSH 4.x → V4 Parsers
-       ▼
-┌─────────────┐
-│    Mesh     │ ◄─── Data model
-└─────────────┘
-```
-
-## Core Components
-
-### 1. Mesh Data Model
-
-The `Mesh` class is the central data structure:
+`MainParser` detects the format and chooses one of these parser lists:
 
 ```python
-class Mesh:
-    - name: str
-    - version: float
-    - node_entities: List[NodeEntity]
-    - element_entities: List[ElementEntity]
-    # ... accessors and methods
+DEFAULT_PARSERS_V1 = [NodesParserV1, ElementsParserV1]
+DEFAULT_PARSERS_V2 = [MeshFormatParser, NodesParserV2, ElementsParserV2]
+DEFAULT_PARSERS_V4 = [MeshFormatParser, NodesParser, ElementsParser]
 ```
 
-**Node hierarchy:**
+A leading `$NOD` selects MSH 1.0. `$MeshFormat` is parsed and validated for MSH
+2.x and 4.x. MSH 2.0, 2.1, and 2.2 share the V2 parsers; MSH 4.0 and 4.1 share
+the V4 parsers.
 
-```
+The main loop dispatches registered section headers to their parser. Optional
+sections without a registered parser are not retained by the data model.
+
+## Data model
+
+```text
 Mesh
-  └─► NodeEntity (dimension, tag, parametric)
-        └─► Node (tag, coordinates)
+  ├─ NodeEntity[]
+  │    └─ Node[]
+  └─ ElementEntity[]
+       └─ Element[]
 ```
 
-**Element hierarchy:**
+`Mesh` stores format metadata, aggregate counts, tag ranges, and entity lists.
+A `Node` stores a tag and coordinates. A `NodeEntity` groups nodes. An `Element`
+stores a tag and connectivity. An `ElementEntity` groups elements with a shared
+dimension, entity tag, and Gmsh element type.
 
-```
-Mesh
-  └─► ElementEntity (dimension, tag, element_type)
-        └─► Element (tag, connectivity)
-```
+Legacy and flat formats are normalized into the same entity-based API used for
+MSH 4.x.
 
-### 2. Parser System
+## Version management
 
-#### Abstract Parser
+`MshFormatVersion` enumerates MSH 1.0, 2.0, 2.1, 2.2, 4.0, and 4.1.
+`VersionManager` parses version strings, validates support, and provides helpers
+for the 1.x, 2.x, and 4.x families.
 
-All parsers inherit from `AbstractParser`:
+## Parser interface
+
+Section parsers implement `AbstractParser`:
 
 ```python
 class AbstractParser:
     @staticmethod
-    def get_section_name() -> str:
-        """Return section name like '$MeshFormat'"""
-        pass
-    
-    @staticmethod
-    def parse(mesh: Mesh, io: TextIO) -> None:
-        """Parse section and populate mesh"""
-        pass
-```
-
-#### Parser Registry
-
-The `MainParser` maintains a registry of parsers:
-
-```python
-DEFAULT_PARSERS = [
-    MeshFormatParser,
-    NodesParser,
-    ElementsParser,
-]
-```
-
-When a section is encountered (e.g., `$Nodes`), `MainParser` finds the appropriate parser and delegates.
-
-### 3. Version Manager
-
-The `VersionManager` handles version detection and validation:
-
-```python
-class MSHVersion(Enum):
-    V1_0 = 1.0
-    V2_0 = 2.0
-    V2_1 = 2.1
-    V2_2 = 2.2
-    V4_0 = 4.0
-    V4_1 = 4.1
-```
-
-Functions:
-
-- `parse_version(version_str: str) -> float`
-- `is_supported(version: float) -> bool`
-- `validate_version(version: float) -> None`
-- `is_version_1(version: float) -> bool`
-- `is_version_2(version: float) -> bool`
-- `is_version_4(version: float) -> bool`
-
-## Parsing Flow
-
-### High-Level Flow
-
-```
-parse("mesh.msh")
-    │
-    ├─► Open file
-    │
-    ├─► Create Mesh object
-    │
-    ├─► MainParser.parse(mesh, file)
-    │     │
-    │     ├─► Detect version (first line)
-    │     │
-    │     ├─► Select parsers based on version
-    │     │
-    │     └─► For each section:
-    │           └─► Find matching parser
-    │               └─► Parser.parse(mesh, file)
-    │
-    └─► Return populated Mesh
-```
-
-### Version Detection
-
-```python
-# Read first line
-line = io.readline().strip()
-
-if line == "$MeshFormat":
-    # MSH 2.x or 4.x
-    version_line = io.readline().strip()
-    version = float(version_line.split()[0])
-elif line == "$NOD":
-    # MSH 1.0 (legacy)
-    version = 1.0
-else:
-    raise ValueError("Unknown format")
-```
-
-### Version-Specific Routing
-
-**MSH 1.0:**
-
-```python
-parsers = [
-    NodesParserV1,      # Parses $NOD section
-    ElementsParserV1,   # Parses $ELM section
-]
-```
-
-**MSH 2.x:**
-
-```python
-parsers = [
-    MeshFormatParser,   # Parses $MeshFormat
-    NodesParser,        # Parses $Nodes (V2 format)
-    ElementsParser,     # Parses $Elements (V2 format)
-]
-```
-
-**MSH 4.x:**
-
-```python
-parsers = [
-    MeshFormatParser,   # Parses $MeshFormat
-    NodesParser,        # Parses $Nodes (V4 format)
-    ElementsParser,     # Parses $Elements (V4 format)
-]
-```
-
-Note: MSH 4.x uses the same parser classes as MSH 2.x, but they handle the format differences internally.
-
-## Module Structure
-
-```
-gmshparser/
-├── __init__.py           # Public API: parse()
-├── mesh.py               # Mesh data model
-├── node.py               # Node class
-├── node_entity.py        # NodeEntity class
-├── element.py            # Element class
-├── element_entity.py     # ElementEntity class
-├── abstract_parser.py    # Parser base class
-├── main_parser.py        # Main parser coordinator
-├── version_manager.py    # Version detection/validation
-├── mesh_format_parser.py # $MeshFormat parser
-├── nodes_parser.py       # $Nodes parser (V2/V4)
-├── nodes_parser_v1.py    # $NOD parser (V1)
-├── nodes_parser_v2.py    # Specialized V2 $Nodes parser
-├── elements_parser.py    # $Elements parser (V2/V4)
-├── elements_parser_v1.py # $ELM parser (V1)
-├── elements_parser_v2.py # Specialized V2 $Elements parser
-├── helpers.py            # Utility functions
-└── cli.py                # Command-line interface
-```
-
-## Data Flow Example
-
-### Parsing MSH 4.1 File
-
-```
-File: mesh.msh (MSH 4.1)
-    │
-    ▼
-$MeshFormat
-4.1 0 8
-$EndMeshFormat
-    │
-    ├─► MeshFormatParser
-    │     └─► mesh.set_version(4.1)
-    │
-$Nodes
-1 6 1 6
-...
-$EndNodes
-    │
-    ├─► NodesParser
-    │     └─► Parse entity blocks
-    │           └─► Create NodeEntity
-    │                 └─► Add Node objects
-    │
-$Elements
-1 2 1 2
-...
-$EndElements
-    │
-    └─► ElementsParser
-          └─► Parse entity blocks
-                └─► Create ElementEntity
-                      └─► Add Element objects
-```
-
-## Extension Points
-
-### Adding a New Parser
-
-To parse a new section (e.g., `$PhysicalNames`):
-
-1. **Create parser class:**
-
-```python
-class PhysicalNamesParser(AbstractParser):
-    @staticmethod
     def get_section_name():
-        return "$PhysicalNames"
-    
+        ...
+
     @staticmethod
-    def parse(mesh: Mesh, io: TextIO) -> None:
-        num_names = int(io.readline().strip())
-        for _ in range(num_names):
-            line = io.readline().strip().split()
-            dimension = int(line[0])
-            tag = int(line[1])
-            name = " ".join(line[2:]).strip('"')
-            # Store in mesh...
+    def parse(mesh, io):
+        ...
 ```
 
-2. **Register parser:**
+The stream is positioned immediately after the section header when `parse()` is
+called.
 
-```python
-# In main_parser.py
-DEFAULT_PARSERS = [
-    MeshFormatParser,
-    PhysicalNamesParser,  # ← Add here
-    NodesParser,
-    ElementsParser,
-]
-```
+## Adding section support
 
-3. **Test:**
+A new section normally requires:
 
-```python
-def test_physical_names_parser():
-    mesh = gmshparser.parse("mesh_with_physical_names.msh")
-    # Verify physical names were parsed...
-```
+1. an `AbstractParser` implementation
+2. data-model changes when values must be exposed
+3. registration in each applicable version-specific parser list
+4. a small fixture and focused tests
+5. updated user and API documentation
 
-### Adding Helper Functions
+The public `gmshparser.parse()` uses the default registries. `MainParser` also
+accepts an explicit parser list for specialized use.
 
-Helper functions for common operations go in `helpers.py`:
+## Helpers
 
-```python
-def get_quads(mesh: Mesh) -> Tuple[List[float], List[float], List[List[int]]]:
-    """Extract quadrilateral elements from mesh."""
-    # Implementation...
-```
+`helpers.py` contains line-parsing utilities and visualization adapters.
+`get_triangles()` and `get_quads()` return zero-based plotting connectivity.
+`get_elements_2d()` returns a dictionary that preserves original Gmsh node tags.
 
-## Performance Considerations
+## Constraints
 
-### Memory
+- the complete mesh is loaded into memory
+- lazy loading and streaming are not implemented
+- the library reads but does not write meshes
+- binary data and many optional MSH sections are not represented
 
-- **Lazy loading**: Not implemented (all data loaded at once)
-- **Memory usage**: Proportional to mesh size
-- **Large meshes**: May require significant RAM
-
-### Speed
-
-- **File I/O**: Uses standard Python `open()`
-- **Parsing**: Simple string operations
-- **Bottleneck**: Usually file I/O, not parsing logic
-
-### Optimization Opportunities
-
-1. **Binary format support**: Faster parsing
-2. **Streaming**: Parse nodes/elements on-demand
-3. **Cython**: Compile performance-critical sections
-4. **NumPy**: Use arrays for coordinate storage
-
-## Testing Architecture
-
-### Test Structure
-
-```
-tests/
-├── test_mesh.py              # Mesh class
-├── test_node.py              # Node class
-├── test_element.py           # Element class
-├── test_mesh_format_parser.py # Format parser
-├── test_nodes_parser.py       # Nodes parser
-├── test_elements_parser.py    # Elements parser
-├── test_multi_version.py      # Version support
-├── test_version_manager.py    # Version detection
-├── test_helpers.py            # Helper functions
-└── test_cli.py                # CLI
-```
-
-### Test Data
-
-Located in `testdata/`:
-
-- Simple meshes for unit tests
-- Complex meshes from real-world use
-- Version-specific meshes (v1.0, v2.0, v4.1, etc.)
-
-## Design Decisions
-
-### Why No Dependencies?
-
-**Pros:**
-
-- Easy installation
-- No dependency conflicts
-- Portable and lightweight
-- Works in restricted environments
-
-**Cons:**
-
-- Can't use NumPy for faster array operations
-- No XML parsing (if needed for newer Gmsh features)
-
-**Decision**: Prioritize simplicity and portability.
-
-### Why Read-Only?
-
-**Rationale:**
-
-- Writing MSH files is complex and error-prone
-- Gmsh itself is better for mesh generation
-- Parser's job is to read, not write
-- Keeps codebase focused
-
-### Why Not Support Binary Format?
-
-**Reasons:**
-
-- Binary format is version-specific
-- Requires careful endianness handling
-- ASCII is "good enough" for most use cases
-- Can be added later if needed
-
-## Future Architecture Considerations
-
-### Potential Improvements
-
-1. **Pluggable parsers**: Allow users to register custom parsers
-2. **Streaming API**: For very large meshes
-3. **Binary support**: Faster parsing
-4. **Writer**: Mesh export functionality
-5. **NumPy integration**: Optional NumPy arrays for coordinates
-
-### Backward Compatibility
-
-All public API changes will:
-
-- Follow semantic versioning
-- Maintain backward compatibility for minor versions
-- Provide deprecation warnings before removal
-
-## Related Documentation
-
-- [Writing Parsers](writing-parsers.md)
-- [Testing Guide](testing.md)
-- [API Reference](../api/overview.md)
+See [Writing Parsers](writing-parsers.md), [Testing](testing.md), and the
+[API Reference](../api/overview.md).

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -48,7 +48,7 @@ git checkout -b feature/your-feature-name
 Run the complete local quality checks:
 
 ```bash
-uv run black . --check
+uv run black gmshparser tests examples --check
 uv run flake8 gmshparser tests
 uv run pytest
 ```
@@ -56,7 +56,7 @@ uv run pytest
 Apply formatting when necessary:
 
 ```bash
-uv run black .
+uv run black gmshparser tests examples
 ```
 
 Run an individual test:

--- a/docs/developer-guide/test-results.md
+++ b/docs/developer-guide/test-results.md
@@ -1,10 +1,11 @@
 # Test Results
 
-gmshparser is tested against mesh files covering the supported MSH format families and multiple element types.
+gmshparser is tested against committed mesh fixtures covering the supported MSH
+version families and several element types.
 
 ## Current automated checks
 
-GitHub Actions runs the project on Python 3.12, 3.13, and 3.14. Every matrix job performs:
+GitHub Actions runs Python 3.12, 3.13, and 3.14. Every matrix job performs:
 
 ```bash
 uv sync --no-default-groups --group test --group lint
@@ -13,49 +14,45 @@ uv run --no-sync flake8 gmshparser tests
 uv run --no-sync pytest --cov=gmshparser --cov-report=xml --cov-report=term
 ```
 
-The documentation workflow separately installs only the `docs` dependency group and runs:
+Python 3.12 also builds the wheel and source distribution and smoke-tests the
+installed package. The release workflow repeats the distribution build and
+smoke tests before publishing.
+
+The documentation workflow installs only the `docs` dependency group and runs:
 
 ```bash
 uv sync --no-default-groups --group docs
 uv run --no-sync mkdocs build
 ```
 
-This separation keeps test environments free of matplotlib and documentation tooling.
-
 ## Format coverage
 
-The test data includes examples for:
+Fixtures and parser tests cover:
 
 - MSH 1.0 legacy `$NOD` and `$ELM` sections
-- MSH 2.0, 2.1, and 2.2 node and element sections
-- physical groups in MSH 2.x files
-- MSH 4.0 and 4.1 entity-based node and element organization
+- MSH 2.0, 2.1, and 2.2 node and element layouts
+- MSH 2.x element records containing tags
+- MSH 4.0 and 4.1 entity-block node and element layouts
+- unsupported-version and version-management behavior
 
-## Element coverage
+The current data model does not expose complete physical-name or physical-tag
+metadata, so the presence of such tags in a fixture should not be described as
+full physical-group support.
 
-The suite exercises elements from zero to three dimensions, including:
+## Element and helper coverage
 
-- points
-- lines
-- triangles
-- quadrangles
-- tetrahedra
+The suite exercises multiple element dimensions and types, including points,
+lines, triangles, quadrangles, and tetrahedra. It also tests the CLI and the
+visualization helper return values.
 
 ## Running tests locally
 
-Install the default development environment:
-
 ```bash
 uv sync
-```
-
-Run the full suite:
-
-```bash
 uv run pytest
 ```
 
-Run one test module:
+Run one module:
 
 ```bash
 uv run pytest tests/test_helpers.py
@@ -67,8 +64,11 @@ Generate an HTML coverage report:
 uv run pytest --cov=gmshparser --cov-report=html
 ```
 
-## Test data organization
+## Authoritative status
 
-Mesh files are stored under `testdata/` and grouped by complexity and purpose. See [`testdata/README.md`](../../testdata/README.md) for details and contribution guidance.
+Mesh files are stored under `testdata/`; see
+[`testdata/README.md`](../../testdata/README.md).
 
-Exact test and coverage totals change as the project evolves. The GitHub Actions result for the current commit is the authoritative status.
+Exact test counts and coverage percentages change as the project evolves. The
+GitHub Actions result and Codecov report for the current commit are the
+authoritative status rather than numbers copied into documentation.

--- a/docs/developer-guide/test-results.md
+++ b/docs/developer-guide/test-results.md
@@ -9,14 +9,14 @@ GitHub Actions runs Python 3.12, 3.13, and 3.14. Every matrix job performs:
 
 ```bash
 uv sync --no-default-groups --group test --group lint
-uv run --no-sync black . --check
+uv run --no-sync black gmshparser tests examples --check
 uv run --no-sync flake8 gmshparser tests
 uv run --no-sync pytest --cov=gmshparser --cov-report=xml --cov-report=term
 ```
 
 Python 3.12 also builds the wheel and source distribution and smoke-tests the
-installed package. The release workflow repeats the distribution build and
-smoke tests before publishing.
+installed package and CLI. The release workflow repeats the distribution build
+and smoke tests before publishing.
 
 The documentation workflow installs only the `docs` dependency group and runs:
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -40,7 +40,7 @@ Open `htmlcov/index.html` in a browser.
 Run the same checks as CI:
 
 ```bash
-uv run black . --check
+uv run black gmshparser tests examples --check
 uv run flake8 gmshparser tests
 uv run pytest --cov=gmshparser --cov-report=xml --cov-report=term
 ```
@@ -48,7 +48,7 @@ uv run pytest --cov=gmshparser --cov-report=xml --cov-report=term
 Apply Black formatting with:
 
 ```bash
-uv run black .
+uv run black gmshparser tests examples
 ```
 
 ## Test data

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,84 +1,93 @@
 # Testing Guide
 
-This guide covers testing practices for gmshparser development.
+The repository uses pytest, pytest-cov, Black, and flake8 through uv dependency
+groups.
 
-## Running Tests
-
-### Run All Tests
-
-```bash
-pytest
-```
-
-### Run Specific Test File
+## Install the development environment
 
 ```bash
-pytest tests/test_helpers.py
+uv sync
 ```
 
-### Run with Coverage
+The default `dev` group includes the `test` and `lint` groups.
+
+## Run the suite
 
 ```bash
-pytest --cov=gmshparser --cov-report=term-missing
+uv run pytest
 ```
 
-### Generate HTML Coverage Report
+The default pytest options in `pyproject.toml` enable verbose output and terminal
+coverage reporting.
+
+Run one module or test:
 
 ```bash
-pytest --cov=gmshparser --cov-report=html
-open htmlcov/index.html
+uv run pytest tests/test_helpers.py
+uv run pytest tests/test_helpers.py::test_get_triangles
 ```
 
-## Writing Tests
+Generate an HTML coverage report:
 
-### Test Structure
+```bash
+uv run pytest --cov=gmshparser --cov-report=html
+```
+
+Open `htmlcov/index.html` in a browser.
+
+## Formatting and linting
+
+Run the same checks as CI:
+
+```bash
+uv run black . --check
+uv run flake8 gmshparser tests
+uv run pytest --cov=gmshparser --cov-report=xml --cov-report=term
+```
+
+Apply Black formatting with:
+
+```bash
+uv run black .
+```
+
+## Test data
+
+Mesh fixtures live under `testdata/`. They include simple version-specific
+meshes and more complex files collected for regression testing. Tests should
+refer to files that are committed to the repository rather than describing or
+assuming uncommitted benchmark datasets.
+
+See [Test Data](../../testdata/README.md) for the current organization.
+
+## Writing tests
+
+A parser test should verify the behavior that callers observe:
 
 ```python
-def test_feature_name():
-    """Test description."""
-    # Arrange - set up test data
-    mesh = gmshparser.parse("testdata/simple/testmesh.msh")
-    
-    # Act - perform action
-    result = mesh.get_nodes()
-    
-    # Assert - verify expectations
-    assert len(result) > 0
-```
+import gmshparser
 
-### Testing Parsers
 
-```python
-def test_parser():
-    """Test parser with known mesh file."""
+def test_mesh_version_and_counts():
     mesh = gmshparser.parse("testdata/simple/testmesh_v2_0.msh")
-    
+
     assert mesh.get_version() == 2.0
     assert mesh.get_number_of_nodes() == 6
     assert mesh.get_number_of_elements() == 2
 ```
 
-## Test Data
+For new behavior:
 
-Test meshes are located in `testdata/`:
+- add the smallest useful mesh fixture
+- verify public API results, not only internal implementation details
+- cover malformed or unsupported input when relevant
+- keep documentation examples consistent with the tested API
 
-- `testdata/simple/` - Simple meshes for unit tests
-- `testdata/complex/` - Complex meshes with mixed elements
-- `testdata/large/` - Large meshes for performance testing
+## Continuous integration
 
-See [testdata/README.md](../../testdata/README.md) for details.
+GitHub Actions runs formatting, linting, tests, distribution builds, and package
+smoke tests on Python 3.12, 3.13, and 3.14. The documentation workflow builds
+MkDocs separately.
 
-## Coverage Goals
-
-- Target: 95%+ coverage
-- Current: 97% coverage
-- All new features must include tests
-
-## Continuous Integration
-
-Tests run automatically on every push via GitHub Actions.
-
-## Next Steps
-
-- See [Test Results](test-results.md) for current test status
-- Check [Contributing Guide](contributing.md) for development workflow
+Exact test counts and coverage percentages change over time. The current CI run
+and Codecov report are the authoritative results.

--- a/docs/developer-guide/writing-parsers.md
+++ b/docs/developer-guide/writing-parsers.md
@@ -148,7 +148,7 @@ Avoid silently inventing defaults for malformed mandatory fields.
 - run Black, flake8, pytest, and the documentation build
 
 ```bash
-uv run black . --check
+uv run black gmshparser tests examples --check
 uv run flake8 gmshparser tests
 uv run pytest
 uv sync --group docs

--- a/docs/developer-guide/writing-parsers.md
+++ b/docs/developer-guide/writing-parsers.md
@@ -1,378 +1,165 @@
-# Writing Custom Parsers
+# Writing Parsers
 
-gmshparser's modular architecture makes it easy to add custom parsers for new mesh file sections.
+A section parser reads one MSH section and stores its data in a `Mesh` or a
+related model object.
 
-## Parser Basics
+## Parser contract
 
-Every parser must:
-
-1. Inherit from `AbstractParser`
-2. Implement `get_section_name()` - returns the section identifier (e.g., `"$PhysicalNames"`)
-3. Implement `parse(mesh, io)` - reads from file and populates mesh
-
-## Simple Example
-
-Here's a parser for the `$PhysicalNames` section:
+A parser implements `AbstractParser` and provides two static methods:
 
 ```python
-from gmshparser.abstract_parser import AbstractParser
-from gmshparser.mesh import Mesh
 from typing import TextIO
 
+from gmshparser.abstract_parser import AbstractParser
+from gmshparser.mesh import Mesh
+
+
+class ExampleParser(AbstractParser):
+    @staticmethod
+    def get_section_name() -> str:
+        return "$Example"
+
+    @staticmethod
+    def parse(mesh: Mesh, io: TextIO) -> None:
+        ...
+```
+
+`MainParser` has already consumed the section header when `parse()` is called.
+The section parser should read exactly the section payload. The main loop can
+then consume and ignore the `$End...` line.
+
+## Example: physical names
+
+gmshparser does not currently retain `$PhysicalNames`. Adding it requires both
+a parser and a place in the data model to store the result.
+
+```python
 class PhysicalNamesParser(AbstractParser):
-    """Parser for $PhysicalNames section."""
-    
     @staticmethod
     def get_section_name() -> str:
         return "$PhysicalNames"
-    
+
     @staticmethod
     def parse(mesh: Mesh, io: TextIO) -> None:
-        """Parse physical names from mesh file.
-        
-        Format:
-            $PhysicalNames
-            <num_names>
-            <dimension> <physical_tag> "<name>"
-            ...
-            $EndPhysicalNames
-        """
-        # Read number of physical names
-        num_names = int(io.readline().strip())
-        
-        # Parse each physical name
-        physical_names = {}
-        for _ in range(num_names):
-            line = io.readline().strip().split(maxsplit=2)
-            dimension = int(line[0])
-            tag = int(line[1])
-            name = line[2].strip('"')
-            physical_names[(dimension, tag)] = name
-        
-        # Store in mesh (you'd need to add this method to Mesh)
-        mesh.set_physical_names(physical_names)
+        count = int(io.readline().strip())
+        names = {}
+
+        for _ in range(count):
+            dimension, tag, quoted_name = io.readline().split(maxsplit=2)
+            names[(int(dimension), int(tag))] = quoted_name.strip().strip('"')
+
+        mesh.set_physical_names(names)
 ```
 
-## Registering Your Parser
+This example assumes that `Mesh` has matching `set_physical_names()` and
+`get_physical_names()` methods. Add and test those methods as part of the same
+change.
 
-Add your parser to the parser registry:
+## Register the parser
+
+The current parser registries are version-specific:
 
 ```python
-# In main_parser.py
-from gmshparser.physical_names_parser import PhysicalNamesParser
+DEFAULT_PARSERS_V1
+DEFAULT_PARSERS_V2
+DEFAULT_PARSERS_V4
+```
 
-DEFAULT_PARSERS = [
+Register the new parser only for formats where the section layout applies. For
+example, a parser shared by MSH 2.x and 4.x would be added to both lists:
+
+```python
+DEFAULT_PARSERS_V2 = [
     MeshFormatParser,
-    PhysicalNamesParser,  # Your custom parser
+    PhysicalNamesParser,
+    NodesParserV2,
+    ElementsParserV2,
+]
+
+DEFAULT_PARSERS_V4 = [
+    MeshFormatParser,
+    PhysicalNamesParser,
     NodesParser,
     ElementsParser,
 ]
 ```
 
-## Testing Your Parser
+Do not add a single `DEFAULT_PARSERS` list: the implementation does not use one.
 
-Create comprehensive tests:
+For specialized callers, `MainParser(parsers=[...])` accepts an explicit parser
+list. That list replaces automatic version-specific selection, so it must
+contain every section parser needed by the input.
 
-```python
-# tests/test_physical_names_parser.py
-import gmshparser
+## Version-specific layouts
 
-def test_physical_names_parser():
-    """Test PhysicalNames parser."""
-    mesh = gmshparser.parse("testdata/physical_names.msh")
-    
-    names = mesh.get_physical_names()
-    assert (2, 1) in names
-    assert names[(2, 1)] == "Surface1"
-```
-
-## Advanced Example: Periodic Entities
-
-For more complex sections:
+When the same section has different layouts, prefer separate parser classes:
 
 ```python
-class PeriodicParser(AbstractParser):
-    """Parser for $Periodic section (MSH 4.x)."""
-    
+class ExampleParserV2(AbstractParser):
     @staticmethod
     def get_section_name() -> str:
-        return "$Periodic"
-    
+        return "$Example"
+
     @staticmethod
     def parse(mesh: Mesh, io: TextIO) -> None:
-        """Parse periodic entity information."""
-        num_periodic = int(io.readline().strip())
-        
-        periodic_entities = []
-        for _ in range(num_periodic):
-            line = io.readline().strip().split()
-            dimension = int(line[0])
-            slave_tag = int(line[1])
-            master_tag = int(line[2])
-            
-            # Read transformation matrix (if present)
-            if len(line) > 3:
-                num_values = int(line[3])
-                transform = [float(io.readline().strip()) for _ in range(num_values)]
-            else:
-                transform = None
-            
-            periodic_entities.append({
-                'dimension': dimension,
-                'slave': slave_tag,
-                'master': master_tag,
-                'transform': transform
-            })
-        
-        mesh.set_periodic_entities(periodic_entities)
-```
+        ...
 
-## Best Practices
 
-### 1. Error Handling
-
-```python
-def parse(mesh: Mesh, io: TextIO) -> None:
-    try:
-        num_items = int(io.readline().strip())
-    except ValueError as e:
-        raise ValueError(f"Invalid format in $Section: {e}")
-    
-    if num_items < 0:
-        raise ValueError(f"Invalid count: {num_items}")
-```
-
-### 2. Type Hints
-
-```python
-from typing import TextIO, List, Dict
-
-def parse(mesh: Mesh, io: TextIO) -> None:
-    data: Dict[int, List[float]] = {}
-    # ...
-```
-
-### 3. Documentation
-
-```python
-def parse(mesh: Mesh, io: TextIO) -> None:
-    """Parse section from mesh file.
-    
-    Args:
-        mesh: Mesh object to populate
-        io: File handle positioned after section header
-    
-    Raises:
-        ValueError: If section format is invalid
-    
-    Example:
-        Format in file:
-            $SectionName
-            <data>
-            $EndSectionName
-    """
-```
-
-### 4. Don't Read the End Marker
-
-The `MainParser` handles `$End*` markers. Your parser should stop before it:
-
-```python
-# ✅ Correct
-def parse(mesh: Mesh, io: TextIO) -> None:
-    count = int(io.readline())
-    for _ in range(count):
-        line = io.readline()
-        # Process line
-    # Stop here - don't read $EndSection
-
-# ❌ Incorrect
-def parse(mesh: Mesh, io: TextIO) -> None:
-    count = int(io.readline())
-    for _ in range(count):
-        line = io.readline()
-    end_marker = io.readline()  # Don't do this!
-```
-
-## Version-Specific Parsers
-
-For sections that differ between versions, use version checks:
-
-```python
-def parse(mesh: Mesh, io: TextIO) -> None:
-    version = mesh.get_version()
-    
-    if version < 2.0:
-        parse_v1_format(mesh, io)
-    elif version < 4.0:
-        parse_v2_format(mesh, io)
-    else:
-        parse_v4_format(mesh, io)
-```
-
-Or create separate parser classes:
-
-```python
-class NodeDataParserV2(AbstractParser):
+class ExampleParserV4(AbstractParser):
     @staticmethod
     def get_section_name() -> str:
-        return "$NodeData"
-    
+        return "$Example"
+
     @staticmethod
     def parse(mesh: Mesh, io: TextIO) -> None:
-        # V2 format parsing
-        pass
-
-class NodeDataParserV4(AbstractParser):
-    @staticmethod
-    def get_section_name() -> str:
-        return "$NodeData"
-    
-    @staticmethod
-    def parse(mesh: Mesh, io: TextIO) -> None:
-        # V4 format parsing
-        pass
+        ...
 ```
 
-## Modifying the Mesh Class
+Register each class in the matching parser list. This follows the existing
+`NodesParserV2`/`NodesParser` and `ElementsParserV2`/`ElementsParser` split.
 
-If your parser needs to store new data:
+## Error handling
+
+Validate section counts and record structure close to where they are read:
 
 ```python
-# In mesh.py
-class Mesh:
-    def __init__(self):
-        # ... existing fields
-        self._physical_names = {}
-    
-    def set_physical_names(self, names: Dict[Tuple[int, int], str]) -> None:
-        """Set physical group names."""
-        self._physical_names = names
-    
-    def get_physical_names(self) -> Dict[Tuple[int, int], str]:
-        """Get physical group names."""
-        return self._physical_names
-    
-    def get_physical_name(self, dimension: int, tag: int) -> str:
-        """Get physical name by dimension and tag."""
-        return self._physical_names.get((dimension, tag), "")
+line = io.readline()
+if not line:
+    raise ValueError("Unexpected end of file in $Example")
+
+try:
+    count = int(line)
+except ValueError as error:
+    raise ValueError(f"Invalid $Example count: {line.strip()}") from error
+
+if count < 0:
+    raise ValueError("$Example count cannot be negative")
 ```
 
-## Complete Example: NodeData Parser
+Avoid silently inventing defaults for malformed mandatory fields.
 
-```python
-from gmshparser.abstract_parser import AbstractParser
-from gmshparser.mesh import Mesh
-from typing import TextIO, List, Dict
+## Testing checklist
 
-class NodeDataParser(AbstractParser):
-    """Parser for $NodeData section (post-processing data)."""
-    
-    @staticmethod
-    def get_section_name() -> str:
-        return "$NodeData"
-    
-    @staticmethod
-    def parse(mesh: Mesh, io: TextIO) -> None:
-        """Parse node data for visualization.
-        
-        Format (MSH 2.x):
-            $NodeData
-            <num_string_tags>
-            "<view_name>"
-            <num_real_tags>
-            <time_value>
-            <num_integer_tags>
-            <time_step>
-            <num_components>
-            <num_nodes>
-            <node_tag> <value1> [<value2> ...]
-            ...
-            $EndNodeData
-        """
-        # String tags
-        num_string_tags = int(io.readline().strip())
-        string_tags = [io.readline().strip().strip('"') for _ in range(num_string_tags)]
-        view_name = string_tags[0] if string_tags else "Unnamed"
-        
-        # Real tags
-        num_real_tags = int(io.readline().strip())
-        real_tags = [float(io.readline().strip()) for _ in range(num_real_tags)]
-        time_value = real_tags[0] if real_tags else 0.0
-        
-        # Integer tags
-        num_integer_tags = int(io.readline().strip())
-        integer_tags = [int(io.readline().strip()) for _ in range(num_integer_tags)]
-        time_step = integer_tags[0] if len(integer_tags) > 0 else 0
-        num_components = integer_tags[1] if len(integer_tags) > 1 else 1
-        num_nodes = integer_tags[2] if len(integer_tags) > 2 else 0
-        
-        # Node data
-        node_data: Dict[int, List[float]] = {}
-        for _ in range(num_nodes):
-            parts = io.readline().strip().split()
-            node_tag = int(parts[0])
-            values = [float(v) for v in parts[1:]]
-            node_data[node_tag] = values
-        
-        # Store in mesh
-        mesh.add_node_data(view_name, {
-            'time': time_value,
-            'time_step': time_step,
-            'components': num_components,
-            'data': node_data
-        })
+- add the smallest valid section fixture
+- verify the values exposed through the public data model
+- cover each applicable MSH version family
+- add malformed-input tests when the parser performs validation
+- ensure an unrelated optional section remains harmless
+- run Black, flake8, pytest, and the documentation build
+
+```bash
+uv run black . --check
+uv run flake8 gmshparser tests
+uv run pytest
+uv sync --group docs
+uv run mkdocs build
 ```
 
-## Debugging Tips
+## Documentation checklist
 
-### 1. Print Debug Info
+Update:
 
-```python
-def parse(mesh: Mesh, io: TextIO) -> None:
-    position = io.tell()
-    print(f"Parsing at position {position}")
-    line = io.readline()
-    print(f"Read line: {line}")
-```
-
-### 2. Validate Input
-
-```python
-def parse(mesh: Mesh, io: TextIO) -> None:
-    line = io.readline().strip()
-    parts = line.split()
-    
-    if len(parts) < 3:
-        raise ValueError(f"Expected at least 3 values, got {len(parts)}: {line}")
-```
-
-### 3. Test with Simple Files
-
-Create minimal test files:
-
-```text
-$MeshFormat
-4.1 0 8
-$EndMeshFormat
-$YourSection
-1
-test data
-$EndYourSection
-```
-
-## Contributing Your Parser
-
-If you've written a useful parser:
-
-1. Add tests
-2. Update documentation
-3. Submit a pull request
-
-See [Contributing Guide](contributing.md) for details.
-
-## Next Steps
-
-- Review [Architecture](architecture.md) for system overview
-- Check [Testing Guide](testing.md) for test practices
-- See [API Reference](../api/parsers.md) for existing parsers
+- [Supported Formats](../user-guide/supported-formats.md) when support changes
+- [Architecture](architecture.md) when routing or data-model structure changes
+- the API reference for new public model methods or parser classes
+- the changelog for user-visible releases

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,113 +1,86 @@
 # gmshparser
 
-[![Python CI - Status][gh-ci-img]][gh-ci-url]
+[![Python CI][gh-ci-img]][gh-ci-url]
+[![codecov][codecov-img]][codecov-url]
 [![PyPI - Version][pypi-img]][pypi-url]
 [![PyPI - Downloads][pypi-dl-img]][pypi-dl-url]
-[![Coverage Status][coveralls-img]][coveralls-url]
-[![Documentation Status][documentation-img]][documentation-url]
+[![Documentation][documentation-img]][documentation-url]
 
-**A lightweight Python package for parsing Gmsh .msh mesh files**
+**A lightweight, dependency-free Python package for parsing ASCII Gmsh MSH files.**
 
-Package author: Jukka Aho ([@ahojukka5](https://github.com/ahojukka5))
+gmshparser reads supported [Gmsh](https://gmsh.info/) mesh formats into a
+consistent Python object model. The package focuses on parsing and inspection;
+it does not write meshes or support binary MSH files.
 
-## Overview
+## Key features
 
-gmshparser is a small Python package designed to do one thing well: parse [Gmsh](https://gmsh.info/)
-mesh file formats. With **no external dependencies** and a clean API, it provides a simple
-stand-alone solution for importing meshes into your FEM research code.
+- MSH 1.0, 2.0, 2.1, 2.2, 4.0, and 4.1 support
+- automatic format-version detection
+- no runtime dependencies
+- Python 3.12 or newer
+- Python API and command-line interface
+- optional matplotlib helpers for 2D meshes
 
-## Key Features
-
-- ✅ **Multiple format support**: MSH 1.0, 2.0, 2.1, 2.2, 4.0, and 4.1
-- ✅ **Automatic version detection**: No need to specify format version
-- ✅ **Zero dependencies**: Pure Python implementation
-- ✅ **100% test coverage**: Thoroughly tested and documented
-- ✅ **Command-line interface**: Extract mesh data from terminal
-- ✅ **Easy visualization**: Built-in matplotlib helpers
-
-## Quick Start
+## Quick start
 
 Install the package:
+
+```bash
+uv add gmshparser
+```
+
+or:
 
 ```bash
 pip install gmshparser
 ```
 
-Parse a mesh file:
+Parse a mesh:
 
 ```python
 import gmshparser
 
 mesh = gmshparser.parse("mesh.msh")
-print(f"Loaded mesh with {mesh.get_number_of_nodes()} nodes "
-      f"and {mesh.get_number_of_elements()} elements")
+print(
+    f"Loaded {mesh.get_number_of_nodes()} nodes and "
+    f"{mesh.get_number_of_elements()} elements"
+)
 ```
 
-## Supported Formats
+## Supported formats
 
-gmshparser supports all major versions of the Gmsh MSH file format:
+| Version | File structure | Status |
+| --- | --- | --- |
+| MSH 1.0 | legacy `$NOD` and `$ELM` sections | supported, ASCII |
+| MSH 2.0–2.2 | `$MeshFormat`, `$Nodes`, and `$Elements` | supported, ASCII |
+| MSH 4.0–4.1 | entity-block node and element sections | supported, ASCII |
 
-| Version | Description | Status |
-|---------|-------------|--------|
-| **MSH 1.0** | Legacy format with `$NOD`/`$ELM` sections | ✅ Supported |
-| **MSH 2.0** | Standard format with `$MeshFormat` | ✅ Supported |
-| **MSH 2.1** | Added `$PhysicalNames` support | ✅ Supported |
-| **MSH 2.2** | Compatible with 2.0/2.1 | ✅ Supported |
-| **MSH 4.0** | Modern format with `$Entities` | ✅ Supported |
-| **MSH 4.1** | Latest version | ✅ Supported |
+See [Supported Formats](user-guide/supported-formats.md) for limitations and
+format-specific notes.
 
-## Documentation Sections
+## Documentation
 
-### [User Guide](user-guide/getting-started.md)
+- [Getting Started](user-guide/getting-started.md)
+- [Basic Usage](user-guide/basic-usage.md)
+- [Command-line Interface](user-guide/cli.md)
+- [Visualization](user-guide/visualization.md)
+- [Contributing](developer-guide/contributing.md)
+- [API Reference](api/overview.md)
 
-Learn how to install, use, and visualize meshes with gmshparser.
+## Project links
 
-### [Developer Guide](developer-guide/contributing.md)
+- [Source repository](https://github.com/ahojukka5/gmshparser)
+- [Issue tracker](https://github.com/ahojukka5/gmshparser/issues)
+- [PyPI package](https://pypi.org/project/gmshparser)
+- [MIT License](about/license.md)
 
-Contribute to the project, understand the architecture, and write custom parsers.
-
-### [API Reference](api/overview.md)
-
-Complete API documentation for all classes and functions.
-
-## Project Links
-
-- **Source Code**: [GitHub Repository](https://github.com/ahojukka5/gmshparser)
-- **Issue Tracker**: [GitHub Issues](https://github.com/ahojukka5/gmshparser/issues)
-- **PyPI Package**: [gmshparser on PyPI](https://pypi.org/project/gmshparser)
-- **License**: [MIT License](about/license.md)
-
-## Quick Example
-
-```python
-import gmshparser
-
-# Parse mesh file
-mesh = gmshparser.parse("data/testmesh.msh")
-
-# Access nodes
-for entity in mesh.get_node_entities():
-    for node in entity.get_nodes():
-        print(f"Node {node.get_tag()}: {node.get_coordinates()}")
-
-# Access elements
-for entity in mesh.get_element_entities():
-    for element in entity.get_elements():
-        print(f"Element {element.get_tag()}: {element.get_connectivity()}")
-```
-
-## Contributing
-
-Contributions are always welcome! Please see our [Contributing Guide](developer-guide/contributing.md)
-for details on how to get started.
-
-[gh-ci-img]: https://github.com/ahojukka5/gmshparser/workflows/Python%20CI/badge.svg
-[gh-ci-url]: https://github.com/ahojukka5/gmshparser/actions
-[coveralls-img]: https://coveralls.io/repos/github/ahojukka5/gmshparser/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/ahojukka5/gmshparser?branch=master
+[gh-ci-img]: https://github.com/ahojukka5/gmshparser/actions/workflows/python.yml/badge.svg
+[gh-ci-url]: https://github.com/ahojukka5/gmshparser/actions/workflows/python.yml
+[codecov-img]: https://codecov.io/gh/ahojukka5/gmshparser/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/ahojukka5/gmshparser
 [pypi-img]: https://img.shields.io/pypi/v/gmshparser
 [pypi-url]: https://pypi.org/project/gmshparser
 [pypi-dl-img]: https://img.shields.io/pypi/dm/gmshparser
 [pypi-dl-url]: https://pypi.org/project/gmshparser
-[documentation-img]: https://readthedocs.org/projects/gmshparser/badge/?version=latest
-[documentation-url]: https://gmshparser.readthedocs.io/en/latest/?badge=latest
+[documentation-img]: https://img.shields.io/badge/docs-GitHub%20Pages-blue
+[documentation-url]: https://ahojukka5.github.io/gmshparser/

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -1,10 +1,6 @@
 # Basic Usage
 
-This guide covers the fundamental usage patterns of gmshparser.
-
-## Parsing a Mesh File
-
-The primary function you'll use is `gmshparser.parse()`:
+## Parse a mesh
 
 ```python
 import gmshparser
@@ -12,247 +8,143 @@ import gmshparser
 mesh = gmshparser.parse("path/to/mesh.msh")
 ```
 
-This automatically detects the file format version and returns a `Mesh` object.
+The parser detects the supported MSH version automatically and returns a
+`Mesh` object.
 
-## Mesh Information
-
-After parsing, you can query basic mesh information:
+## Mesh metadata
 
 ```python
-# Get mesh metadata
-print(f"Mesh name: {mesh.get_name()}")
-print(f"Mesh version: {mesh.get_version()}")
-print(f"Number of nodes: {mesh.get_number_of_nodes()}")
-print(f"Number of elements: {mesh.get_number_of_elements()}")
-
-# Get node tag ranges
-print(f"Min node tag: {mesh.get_min_node_tag()}")
-print(f"Max node tag: {mesh.get_max_node_tag()}")
-
-# Get element tag ranges
-print(f"Min element tag: {mesh.get_min_element_tag()}")
-print(f"Max element tag: {mesh.get_max_element_tag()}")
-
-# Get entity counts
-print(f"Node entities: {mesh.get_number_of_node_entities()}")
-print(f"Element entities: {mesh.get_number_of_element_entities()}")
+print(mesh.get_name())
+print(mesh.get_version())
+print(mesh.get_number_of_nodes())
+print(mesh.get_number_of_elements())
+print(mesh.get_min_node_tag(), mesh.get_max_node_tag())
+print(mesh.get_min_element_tag(), mesh.get_max_element_tag())
+print(mesh.get_number_of_node_entities())
+print(mesh.get_number_of_element_entities())
 ```
 
-## Working with Nodes
+## Nodes
 
-Nodes in gmshparser are organized by entities. Here's how to access them:
-
-### Iterate All Nodes
+Nodes are grouped into node entities:
 
 ```python
 for entity in mesh.get_node_entities():
+    print(
+        "entity",
+        entity.get_dimension(),
+        entity.get_tag(),
+        entity.get_number_of_nodes(),
+    )
+
     for node in entity.get_nodes():
         node_id = node.get_tag()
-        coords = node.get_coordinates()
-        x, y, z = coords
-        print(f"Node {node_id}: ({x}, {y}, {z})")
+        x, y, z = node.get_coordinates()
+        print(node_id, x, y, z)
 ```
 
-### Get Specific Node Data
+## Elements
 
-```python
-# Get all nodes from first entity
-first_entity = mesh.get_node_entities()[0]
-nodes = first_entity.get_nodes()
-
-# Access node properties
-for node in nodes:
-    tag = node.get_tag()          # Node ID
-    coords = node.get_coordinates()  # (x, y, z) tuple
-    x = coords[0]
-    y = coords[1]
-    z = coords[2]
-```
-
-### Entity Information
-
-```python
-for entity in mesh.get_node_entities():
-    dimension = entity.get_dimension()
-    entity_tag = entity.get_tag()
-    num_nodes = entity.get_number_of_nodes()
-    print(f"Entity {entity_tag} (dim={dimension}): {num_nodes} nodes")
-```
-
-## Working with Elements
-
-Elements are also organized by entities:
-
-### Iterate All Elements
+Elements are grouped into element entities. The entity stores the Gmsh element
+type shared by its elements:
 
 ```python
 for entity in mesh.get_element_entities():
     element_type = entity.get_element_type()
-    print(f"Element type: {element_type}")
-    
+    print(
+        "entity",
+        entity.get_dimension(),
+        entity.get_tag(),
+        element_type,
+        entity.get_number_of_elements(),
+    )
+
     for element in entity.get_elements():
-        elem_id = element.get_tag()
-        connectivity = element.get_connectivity()
-        print(f"Element {elem_id}: nodes {connectivity}")
+        print(element.get_tag(), element.get_connectivity())
 ```
 
-### Element Types
+Gmsh element types are numeric. Common values include 1 for a two-node line, 2
+for a three-node triangle, 3 for a four-node quadrangle, and 4 for a
+four-node tetrahedron. Consult the official Gmsh MSH specification for the full
+list.
 
-Gmsh uses numeric codes for element types:
-
-| Code | Element Type | Nodes |
-|------|-------------|--------|
-| 15 | Point | 1 |
-| 1 | Line | 2 |
-| 2 | Triangle | 3 |
-| 3 | Quadrangle | 4 |
-| 4 | Tetrahedron | 4 |
-| 5 | Hexahedron | 8 |
-| 8 | Line (3-node) | 3 |
-| 9 | Triangle (6-node) | 6 |
-| ... | ... | ... |
-
-See the [Gmsh documentation](https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format) for a complete list.
-
-### Filter Elements by Type
+## Filter by element type
 
 ```python
-# Get all triangular elements
+triangles = []
 for entity in mesh.get_element_entities():
-    if entity.get_element_type() == 2:  # Triangle
-        for element in entity.get_elements():
-            print(f"Triangle {element.get_tag()}: {element.get_connectivity()}")
+    if entity.get_element_type() == 2:
+        triangles.extend(
+            element.get_connectivity() for element in entity.get_elements()
+        )
 ```
 
-## Using Helper Functions
+## Visualization helpers
 
-gmshparser provides helper functions for common tasks:
+### Triangles
 
-### Extract Triangles for Plotting
+`get_triangles()` returns coordinate arrays and zero-based connectivity suitable
+for matplotlib:
 
 ```python
 from gmshparser.helpers import get_triangles
 
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-# X, Y: coordinate arrays
-# T: connectivity array for matplotlib.triplot
+X, Y, triangles = get_triangles(mesh)
 ```
 
-### Extract Quadrilaterals
+### Quadrangles
+
+`get_quads()` uses the same zero-based indexing convention:
 
 ```python
 from gmshparser.helpers import get_quads
 
-mesh = gmshparser.parse("mesh.msh")
-X, Y, Q = get_quads(mesh)
-
-# Q: quadrilateral connectivity array
+X, Y, quads = get_quads(mesh)
 ```
 
-### Extract All 2D Elements
+### Mixed 2D meshes
+
+`get_elements_2d()` returns a dictionary. Its element connectivity retains the
+original Gmsh node tags rather than converting them to zero-based indices:
 
 ```python
 from gmshparser.helpers import get_elements_2d
 
-mesh = gmshparser.parse("mesh.msh")
-X, Y, triangles, quads = get_elements_2d(mesh)
+data = get_elements_2d(mesh)
 
-# Returns both triangles and quads
+nodes = data["nodes"]          # node tag -> (x, y)
+triangles = data["triangles"] # connectivity using node tags
+quads = data["quads"]         # connectivity using node tags
+node_ids = data["node_ids"]
 ```
 
-## Practical Examples
+See [Visualization](visualization.md) for plotting examples.
 
-### Example 1: Export Nodes to CSV
+## Export nodes to CSV
 
 ```python
-import gmshparser
 import csv
 
-mesh = gmshparser.parse("mesh.msh")
+with open("nodes.csv", "w", newline="") as stream:
+    writer = csv.writer(stream)
+    writer.writerow(["id", "x", "y", "z"])
 
-with open("nodes.csv", "w", newline="") as f:
-    writer = csv.writer(f)
-    writer.writerow(["ID", "X", "Y", "Z"])
-    
     for entity in mesh.get_node_entities():
         for node in entity.get_nodes():
-            tag = node.get_tag()
-            x, y, z = node.get_coordinates()
-            writer.writerow([tag, x, y, z])
+            writer.writerow([node.get_tag(), *node.get_coordinates()])
 ```
 
-### Example 2: Count Element Types
+## Error handling
 
 ```python
-import gmshparser
-from collections import Counter
-
-mesh = gmshparser.parse("mesh.msh")
-
-element_types = Counter()
-for entity in mesh.get_element_entities():
-    elem_type = entity.get_element_type()
-    elem_count = entity.get_number_of_elements()
-    element_types[elem_type] += elem_count
-
-for elem_type, count in element_types.items():
-    print(f"Type {elem_type}: {count} elements")
-```
-
-### Example 3: Build a Connectivity Matrix
-
-```python
-import gmshparser
-import numpy as np
-
-mesh = gmshparser.parse("mesh.msh")
-
-# Collect all triangular elements
-triangles = []
-for entity in mesh.get_element_entities():
-    if entity.get_element_type() == 2:  # Triangle
-        for element in entity.get_elements():
-            triangles.append(element.get_connectivity())
-
-# Convert to numpy array
-connectivity = np.array(triangles)
-print(f"Triangle connectivity shape: {connectivity.shape}")
-```
-
-## Working with Different MSH Versions
-
-gmshparser handles version differences automatically:
-
-```python
-# Works with any supported version (1.0, 2.0, 2.1, 2.2, 4.0, 4.1)
-mesh = gmshparser.parse("any_version.msh")
-
-# Check which version was detected
-version = mesh.get_version()
-print(f"Detected MSH version: {version}")
-```
-
-The API remains consistent regardless of the file format version.
-
-## Error Handling
-
-Handle parsing errors gracefully:
-
-```python
-import gmshparser
-
 try:
     mesh = gmshparser.parse("mesh.msh")
 except FileNotFoundError:
     print("Mesh file not found")
-except Exception as e:
-    print(f"Error parsing mesh: {e}")
+except ValueError as error:
+    print(f"Unsupported or invalid MSH file: {error}")
 ```
 
-## Next Steps
-
-- Learn about the [Command Line Interface](cli.md)
-- Explore [Visualization options](visualization.md)
-- Check the [API Reference](../api/overview.md)
+Unexpected or malformed section contents may also raise parsing-related Python
+exceptions. When reporting such a case, include the smallest mesh file that
+reproduces it.

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -1,244 +1,100 @@
-# Command Line Interface
+# Command-line Interface
 
-gmshparser includes a command-line interface (CLI) for quick mesh inspection and data extraction without writing Python code.
-
-## Basic Usage
-
-After installing gmshparser, the `gmshparser` command is available in your terminal:
+The installed `gmshparser` command provides three read-only views of an ASCII
+MSH file:
 
 ```bash
-gmshparser <mesh_file> <command>
+gmshparser <mesh-file> {info,nodes,elements}
 ```
 
-## Available Commands
+Use `uv run gmshparser` when running inside a uv-managed project.
 
-### `nodes` - Extract Node Data
+## Mesh summary
 
-Extract all nodes in a simple format:
+```bash
+gmshparser mesh.msh info
+```
+
+The `info` action prints the same summary as `print(mesh)` in the Python API.
+
+## Nodes
 
 ```bash
 gmshparser mesh.msh nodes
 ```
 
-**Output format:**
+The first line is the total node count. Each following line contains:
 
 ```text
-<number_of_nodes>
-<node_id> <x> <y> <z>
-<node_id> <x> <y> <z>
-...
+node_id x y z
 ```
 
-**Example:**
+Example:
 
-```bash
-$ gmshparser data/testmesh.msh nodes
+```text
 6
 1 0.000000 0.000000 0.000000
 2 1.000000 0.000000 0.000000
-3 1.000000 1.000000 0.000000
-4 0.000000 1.000000 0.000000
-5 2.000000 0.000000 0.000000
-6 2.000000 1.000000 0.000000
 ```
 
-### `elements` - Extract Element Data
-
-Extract all elements with their connectivity:
+## Elements
 
 ```bash
 gmshparser mesh.msh elements
 ```
 
-**Output format:**
+The first line is the total element count. Each following line contains:
 
 ```text
-<number_of_elements>
-<element_id> <element_type> <node_1> <node_2> ... <node_n>
-<element_id> <element_type> <node_1> <node_2> ... <node_n>
-...
+element_id element_type node_id...
 ```
 
-**Example:**
+Example:
 
-```bash
-$ gmshparser data/testmesh.msh elements
+```text
 2
 1 3 1 2 3 4
 2 3 2 5 6 3
 ```
 
-## Practical Use Cases
-
-### 1. Quick Mesh Inspection
-
-Check mesh contents without writing code:
-
-```bash
-# Count nodes
-gmshparser mesh.msh nodes | wc -l
-
-# Count elements
-gmshparser mesh.msh elements | wc -l
-
-# View first 10 nodes
-gmshparser mesh.msh nodes | head -n 11
-```
-
-### 2. Import to Other Languages
-
-The simple output format makes it easy to read mesh data in C, C++, Fortran, or other languages:
-
-**C++ Example:**
-
-```cpp
-#include <iostream>
-#include <fstream>
-
-int main() {
-    std::ifstream nodes("nodes.txt");
-    int num_nodes;
-    nodes >> num_nodes;
-    
-    for (int i = 0; i < num_nodes; ++i) {
-        int id;
-        double x, y, z;
-        nodes >> id >> x >> y >> z;
-        std::cout << "Node " << id << ": (" << x << ", " << y << ", " << z << ")\n";
-    }
-    
-    return 0;
-}
-```
-
-**Fortran Example:**
-
-```fortran
-program read_mesh
-    implicit none
-    integer :: num_nodes, i, node_id
-    real(8) :: x, y, z
-    
-    open(unit=10, file='nodes.txt', status='old')
-    read(10, *) num_nodes
-    
-    do i = 1, num_nodes
-        read(10, *) node_id, x, y, z
-        write(*, '(A,I0,A,3F12.6)') 'Node ', node_id, ': ', x, y, z
-    end do
-    
-    close(10)
-end program read_mesh
-```
-
-### 3. Pipeline Processing
-
-Combine with shell tools for data processing:
-
-```bash
-# Extract nodes and save to file
-gmshparser mesh.msh nodes > nodes.txt
-
-# Extract elements and save to file
-gmshparser mesh.msh elements > elements.txt
-
-# Extract only node coordinates (skip IDs)
-gmshparser mesh.msh nodes | tail -n +2 | awk '{print $2, $3, $4}'
-
-# Count triangular elements (type 2)
-gmshparser mesh.msh elements | grep "^[0-9]* 2 " | wc -l
-```
-
-### 4. Batch Processing
-
-Process multiple meshes:
-
-```bash
-#!/bin/bash
-for mesh in *.msh; do
-    echo "Processing $mesh"
-    gmshparser "$mesh" nodes > "${mesh%.msh}_nodes.txt"
-    gmshparser "$mesh" elements > "${mesh%.msh}_elements.txt"
-done
-```
-
-### 5. Data Validation
-
-Quickly check mesh integrity:
-
-```bash
-# Check if mesh has nodes
-if [ $(gmshparser mesh.msh nodes | head -n 1) -gt 0 ]; then
-    echo "Mesh has nodes"
-else
-    echo "Warning: Empty mesh"
-fi
-
-# Count element types
-echo "Element type distribution:"
-gmshparser mesh.msh elements | tail -n +2 | awk '{print $2}' | sort | uniq -c
-```
-
-## Getting Help
-
-Display CLI help:
+## Help and version
 
 ```bash
 gmshparser --help
-```
-
-Or check the version:
-
-```bash
 gmshparser --version
 ```
 
-## Output Redirection
+Argument errors are reported by Python's `argparse` command-line parser. File
+and parsing errors are currently propagated from the Python API.
 
-Save output to files:
+## Shell pipelines
 
-```bash
-# Save nodes
-gmshparser mesh.msh nodes > mesh_nodes.txt
-
-# Save elements
-gmshparser mesh.msh elements > mesh_elements.txt
-
-# Append to existing file
-gmshparser mesh.msh nodes >> all_nodes.txt
-```
-
-## Error Handling
-
-The CLI provides clear error messages:
+Save the output:
 
 ```bash
-$ gmshparser nonexistent.msh nodes
-Error: File 'nonexistent.msh' not found
-
-$ gmshparser mesh.msh invalid_command
-Error: Unknown command 'invalid_command'
-Valid commands: nodes, elements
+gmshparser mesh.msh nodes > nodes.txt
+gmshparser mesh.msh elements > elements.txt
 ```
 
-## Performance
+Skip the count line and print only node coordinates:
 
-The CLI is optimized for quick extraction:
+```bash
+gmshparser mesh.msh nodes | tail -n +2 | awk '{print $2, $3, $4}'
+```
 
-- Small meshes (< 10K nodes): Instant
-- Medium meshes (10K-100K nodes): < 1 second
-- Large meshes (> 100K nodes): Few seconds
+Count element types:
+
+```bash
+gmshparser mesh.msh elements \
+  | tail -n +2 \
+  | awk '{print $2}' \
+  | sort \
+  | uniq -c
+```
 
 ## Limitations
 
-- No filtering options (use shell tools like `grep`, `awk`)
-- Fixed output format (for flexibility, use the Python API)
-- No mesh modification (CLI is read-only)
-
-For more complex operations, use the [Python API](basic-usage.md).
-
-## Next Steps
-
-- Learn about [Visualization](visualization.md)
-- Explore the [Python API](basic-usage.md)
-- Check [Supported Formats](supported-formats.md)
+- the CLI reads but does not modify meshes
+- output formats are fixed and line-oriented
+- filtering is delegated to shell tools or the Python API
+- only ASCII MSH files supported by the library can be read

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,69 +1,73 @@
 # Getting Started
 
-Welcome to gmshparser! This guide will help you get started with parsing Gmsh mesh files in Python.
+gmshparser is a lightweight Python library for reading ASCII Gmsh `.msh`
+files. It parses the mesh into objects representing nodes, elements, and their
+entities.
 
-## What is gmshparser?
+## Requirements
 
-gmshparser is a lightweight Python library for reading Gmsh `.msh` files. It focuses on doing one thing well: parsing mesh files with a clean, simple API.
+- Python 3.12 or newer
+- no runtime dependencies for parsing
+- matplotlib only for the optional visualization examples
 
-## Why gmshparser?
+## Supported files
 
-- **No external dependencies**: Pure Python implementation
-- **Universal format support**: Works with MSH 1.0 through 4.1
-- **Automatic detection**: Detects file format version automatically
-- **Well tested**: 100% test coverage with 34+ test cases
-- **Easy to use**: Simple, intuitive API
+The parser detects these MSH versions automatically:
 
-## What can you do with gmshparser?
+- 1.0
+- 2.0, 2.1, and 2.2
+- 4.0 and 4.1
 
-- Parse Gmsh mesh files of any supported version
-- Extract nodes and their coordinates
-- Extract elements and their connectivity
-- Access physical groups and entities
-- Export mesh data for other FEM codes
-- Visualize 2D meshes using matplotlib
+Only ASCII MSH files are supported. See [Supported Formats](supported-formats.md)
+for details and limitations.
 
-## System Requirements
+## Install
 
-- Python 3.8.1 or later
-- No external dependencies required for core functionality
-- matplotlib (optional, for visualization)
+```bash
+uv add gmshparser
+```
 
-## Next Steps
+or:
 
-1. [Install gmshparser](installation.md)
-2. [Learn basic usage](basic-usage.md)
-3. [Try the command-line interface](cli.md)
-4. [Visualize your meshes](visualization.md)
+```bash
+pip install gmshparser
+```
 
-## Quick Example
-
-Here's a simple example to get you started:
+## Parse a mesh
 
 ```python
 import gmshparser
 
-# Parse a mesh file
-mesh = gmshparser.parse("my_mesh.msh")
-
-# Print mesh information
-print(f"Mesh version: {mesh.get_version()}")
-print(f"Number of nodes: {mesh.get_number_of_nodes()}")
-print(f"Number of elements: {mesh.get_number_of_elements()}")
-
-# Access first node
-for entity in mesh.get_node_entities():
-    for node in entity.get_nodes():
-        print(f"First node: {node.get_tag()} at {node.get_coordinates()}")
-        break
-    break
+mesh = gmshparser.parse("mesh.msh")
+print(f"MSH version: {mesh.get_version()}")
+print(f"Nodes: {mesh.get_number_of_nodes()}")
+print(f"Elements: {mesh.get_number_of_elements()}")
 ```
 
-## Getting Help
+## Inspect nodes
 
-If you encounter issues or have questions:
+```python
+for entity in mesh.get_node_entities():
+    for node in entity.get_nodes():
+        print(node.get_tag(), node.get_coordinates())
+```
 
-- Check the [API Reference](../api/overview.md)
-- Review [examples in the repository](https://github.com/ahojukka5/gmshparser/tree/master/examples)
-- [Open an issue on GitHub](https://github.com/ahojukka5/gmshparser/issues)
-- Contact the author: <ahojukka5@gmail.com>
+## Inspect elements
+
+```python
+for entity in mesh.get_element_entities():
+    element_type = entity.get_element_type()
+    for element in entity.get_elements():
+        print(element.get_tag(), element_type, element.get_connectivity())
+```
+
+## Next steps
+
+1. [Installation and development setup](installation.md)
+2. [Basic API usage](basic-usage.md)
+3. [Command-line interface](cli.md)
+4. [Visualization helpers](visualization.md)
+5. [Repository test meshes](https://github.com/ahojukka5/gmshparser/tree/master/testdata)
+
+For bugs or unsupported files, open an issue and attach the smallest mesh that
+reproduces the problem.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,25 +1,27 @@
 # Installation
 
-## Install from PyPI
+## Stable release
 
-Install the latest stable release with `uv`:
+Add gmshparser to a uv-managed project:
 
 ```bash
 uv add gmshparser
 ```
 
-The package can also be installed with pip:
+Install it into the active Python environment with pip:
 
 ```bash
 pip install gmshparser
 ```
 
-## Install the development version
+The package requires Python 3.12 or newer.
 
-Install directly from GitHub:
+## Development version
+
+Install the current `master` branch directly from GitHub:
 
 ```bash
-uv add git+https://github.com/ahojukka5/gmshparser.git
+uv add "gmshparser @ git+https://github.com/ahojukka5/gmshparser.git"
 ```
 
 or with pip:
@@ -28,29 +30,37 @@ or with pip:
 pip install git+https://github.com/ahojukka5/gmshparser.git
 ```
 
-## Visualization dependencies
+## Verify the installation
 
-The parser itself does not depend on matplotlib. Install it separately when using the visualization examples:
+```bash
+python -c "import gmshparser; print(gmshparser.__version__)"
+gmshparser --version
+```
+
+In a uv-managed project, prefix commands with `uv run` when needed:
+
+```bash
+uv run python -c "import gmshparser; print(gmshparser.__version__)"
+uv run gmshparser --version
+```
+
+## Visualization dependency
+
+The core package does not depend on matplotlib. Add it only for visualization:
 
 ```bash
 uv add matplotlib
 ```
 
-For a repository checkout, the predefined dependency group can be used instead:
+For a repository checkout, use the predefined dependency group:
 
 ```bash
 uv sync --group visualization
 ```
 
-## Verify the installation
+## Development environment
 
-```bash
-uv run python -c "import gmshparser; print(gmshparser.__version__)"
-```
-
-## Development installation
-
-Clone the repository and let `uv` create the environment:
+Clone the repository and let uv create the local environment:
 
 ```bash
 git clone https://github.com/ahojukka5/gmshparser.git
@@ -58,20 +68,16 @@ cd gmshparser
 uv sync
 ```
 
-The default development environment contains the `test` and `lint` groups. Other groups are installed explicitly:
+The default `dev` group includes the `test` and `lint` groups. Install other
+groups explicitly:
 
 ```bash
-# Documentation toolchain
 uv sync --group docs
-
-# Visualization examples
 uv sync --group visualization
-
-# Every development group
 uv sync --all-groups
 ```
 
-Run commands through the managed environment:
+Run project commands through uv:
 
 ```bash
 uv run pytest
@@ -79,32 +85,15 @@ uv run black . --check
 uv run flake8 gmshparser tests
 ```
 
-Dependency lock files are intentionally not committed in this repository. `uv` may create a local `uv.lock`; it is ignored by Git.
+Dependency lock files are intentionally not committed. A locally generated
+`uv.lock` is ignored by Git.
 
-## System requirements
+## Upgrade
 
-- Python 3.12 or later
-- A current version of `uv`, recommended for development
-
-## Troubleshooting
-
-Check the interpreter selected by `uv`:
+In a uv project:
 
 ```bash
-uv run python --version
-```
-
-Recreate the environment when dependency state becomes inconsistent:
-
-```bash
-rm -rf .venv uv.lock
-uv sync
-```
-
-## Upgrading
-
-```bash
-uv add --upgrade gmshparser
+uv add gmshparser --upgrade-package gmshparser
 ```
 
 With pip:
@@ -113,7 +102,9 @@ With pip:
 pip install --upgrade gmshparser
 ```
 
-## Uninstalling
+## Uninstall
+
+Remove the dependency from a uv project:
 
 ```bash
 uv remove gmshparser

--- a/docs/user-guide/supported-formats.md
+++ b/docs/user-guide/supported-formats.md
@@ -23,11 +23,8 @@ common Python API. It does not mean that every optional MSH section is retained.
 
 The `$MeshFormat` file-type field is recorded in the `Mesh` object, but the
 parser reads the file as text. Binary MSH files are therefore not supported.
-Convert them to ASCII with Gmsh before parsing.
-
-```bash
-gmsh input.msh -format msh41 -bin 0 -o output.msh
-```
+Export them from Gmsh with `Mesh.Binary = 0` and select a supported MSH version
+before parsing.
 
 ## MSH 1.0
 

--- a/docs/user-guide/supported-formats.md
+++ b/docs/user-guide/supported-formats.md
@@ -1,23 +1,38 @@
 # Supported Formats
 
-gmshparser supports multiple versions of the Gmsh MSH file format, automatically detecting the version and using the appropriate parser.
+gmshparser reads the node and element data from selected **ASCII** Gmsh MSH
+formats. The version is detected automatically from `$MeshFormat`, or from the
+legacy `$NOD` header for MSH 1.0.
 
-## Format Overview
+## Supported versions
 
-| Version | Status | Description |
-|---------|--------|-------------|
-| MSH 1.0 | ✅ Fully Supported | Legacy format |
-| MSH 2.0 | ✅ Fully Supported | Standard format |
-| MSH 2.1 | ✅ Fully Supported | With physical names |
-| MSH 2.2 | ✅ Fully Supported | Compatible with 2.0/2.1 |
-| MSH 4.0 | ✅ Fully Supported | Modern entity-based format |
-| MSH 4.1 | ✅ Fully Supported | Latest version |
+| Version | Node and element layout | Status |
+| --- | --- | --- |
+| MSH 1.0 | legacy `$NOD` and `$ELM` sections | supported |
+| MSH 2.0 | flat `$Nodes` and `$Elements` sections | supported |
+| MSH 2.1 | flat `$Nodes` and `$Elements` sections | supported |
+| MSH 2.2 | flat `$Nodes` and `$Elements` sections | supported |
+| MSH 4.0 | entity-block `$Nodes` and `$Elements` sections | supported |
+| MSH 4.1 | entity-block `$Nodes` and `$Elements` sections | supported |
 
-## MSH 1.0 (Legacy Format)
+“Supported” here means that the core mesh topology—node coordinates, element
+connectivity, entity grouping, counts, and tag ranges—can be read through the
+common Python API. It does not mean that every optional MSH section is retained.
 
-The original Gmsh format using simple section markers.
+## ASCII only
 
-### Structure
+The `$MeshFormat` file-type field is recorded in the `Mesh` object, but the
+parser reads the file as text. Binary MSH files are therefore not supported.
+Convert them to ASCII with Gmsh before parsing.
+
+```bash
+gmsh input.msh -format msh41 -bin 0 -o output.msh
+```
+
+## MSH 1.0
+
+MSH 1.0 files have no `$MeshFormat` section. gmshparser recognizes the legacy
+headers:
 
 ```text
 $NOD
@@ -27,295 +42,86 @@ $NOD
 $ENDNOD
 $ELM
 <number-of-elements>
-<elm-number> <elm-type> <reg-phys> <reg-elem> <number-of-nodes> <node-list>
+<element-records>
 ...
 $ENDELM
 ```
 
-### Features
+The parser converts the legacy flat data into the same `Mesh`, `NodeEntity`, and
+`ElementEntity` model used for later versions.
 
-- No `$MeshFormat` section
-- Simple node and element sections
-- Legacy element type numbering
-- Physical and elementary region tags
+## MSH 2.x
 
-### Example
+For MSH 2.0, 2.1, and 2.2, gmshparser parses:
 
-```text
-$NOD
-6
-1 0.0 0.0 0.0
-2 1.0 0.0 0.0
-3 1.0 1.0 0.0
-4 0.0 1.0 0.0
-5 2.0 0.0 0.0
-6 2.0 1.0 0.0
-$ENDNOD
-$ELM
-2
-1 3 0 1 4 1 2 3 4
-2 3 0 1 4 2 5 6 3
-$ENDELM
-```
+- `$MeshFormat`
+- `$Nodes`
+- `$Elements`
 
-## MSH 2.0/2.1/2.2 (Standard Format)
+Element records may contain physical, elementary, and partition tags. The
+current parser uses the elementary entity tag for grouping but does not expose
+the complete tag list on each element.
 
-The widely-used standard format with `$MeshFormat` section.
+`$PhysicalNames` and other optional sections are not stored by the current data
+model.
 
-### Structure
+## MSH 4.x
 
-```text
-$MeshFormat
-<version> <file-type> <data-size>
-$EndMeshFormat
-$Nodes
-<number-of-nodes>
-<node-id> <x> <y> <z>
-...
-$EndNodes
-$Elements
-<number-of-elements>
-<elm-id> <elm-type> <number-of-tags> <tag-list> <node-list>
-...
-$EndElements
-```
+For MSH 4.0 and 4.1, gmshparser parses the entity-block forms of `$Nodes` and
+`$Elements` and stores each block as a node or element entity.
 
-### MSH 2.1 Addition
+The standalone `$Entities` section and its geometry, bounding boxes, topology,
+and physical tags are not retained. Entity dimension and tag values available
+in the node and element block headers are preserved.
 
-```text
-$PhysicalNames
-<number-of-physical-names>
-<dimension> <physical-tag> "<physical-name>"
-...
-$EndPhysicalNames
-```
+## Common limitations
 
-### Features
+The current reader does not provide:
 
-- Explicit version declaration
-- Node and element sections with clear syntax
-- Support for element tags (physical, elementary, partition)
-- Optional physical group names (2.1+)
-- ASCII or binary formats supported
+- binary MSH support
+- mesh writing or format conversion
+- compressed-file handling
+- preservation of every optional MSH section
+- post-processing datasets such as `$NodeData`, `$ElementData`, or
+  `$ElementNodeData`
+- periodic-entity metadata
+- complete physical-name and physical-tag metadata
 
-### Example (MSH 2.2)
+Unknown sections are skipped by the main parsing loop unless a parser for that
+section is registered in the relevant version-specific parser list.
 
-```text
-$MeshFormat
-2.2 0 8
-$EndMeshFormat
-$Nodes
-6
-1 0.0 0.0 0.0
-2 1.0 0.0 0.0
-3 1.0 1.0 0.0
-4 0.0 1.0 0.0
-5 2.0 0.0 0.0
-6 2.0 1.0 0.0
-$EndNodes
-$Elements
-2
-1 3 2 1 1 1 2 3 4
-2 3 2 1 1 2 5 6 3
-$EndElements
-```
+## Element types
 
-## MSH 4.0/4.1 (Modern Format)
+Element type codes are stored as the numeric values defined by Gmsh. Common
+codes include:
 
-The current Gmsh format with entity-based organization.
+| Code | Element | Dimension |
+| --- | --- | --- |
+| 15 | point | 0 |
+| 1 | two-node line | 1 |
+| 2 | three-node triangle | 2 |
+| 3 | four-node quadrangle | 2 |
+| 4 | four-node tetrahedron | 3 |
+| 5 | eight-node hexahedron | 3 |
+| 6 | six-node prism | 3 |
+| 7 | five-node pyramid | 3 |
 
-### Structure
+The parser also recognizes several higher-order element codes when deriving the
+entity dimension. Refer to the official Gmsh MSH specification for the complete
+code table.
 
-```text
-$MeshFormat
-<version> <file-type> <data-size>
-$EndMeshFormat
-$Entities
-<numPoints> <numCurves> <numSurfaces> <numVolumes>
-<point-entities>
-<curve-entities>
-<surface-entities>
-<volume-entities>
-$EndEntities
-$Nodes
-<numEntityBlocks> <numNodes> <minNodeTag> <maxNodeTag>
-<entityDim> <entityTag> <parametric> <numNodesInBlock>
-<nodeTag>
-...
-<x> <y> <z>
-...
-$EndNodes
-$Elements
-<numEntityBlocks> <numElements> <minElementTag> <maxElementTag>
-<entityDim> <entityTag> <elementType> <numElementsInBlock>
-<elementTag> <nodeTag1> <nodeTag2> ...
-...
-$EndElements
-```
-
-### Features
-
-- Entity-based organization (points, curves, surfaces, volumes)
-- Explicit entity topology
-- Node and element blocks grouped by entity
-- More efficient for large meshes
-- Better support for high-order elements
-
-### Example (MSH 4.1)
-
-```text
-$MeshFormat
-4.1 0 8
-$EndMeshFormat
-$Nodes
-1 6 1 6
-2 1 0 6
-1
-2
-3
-4
-5
-6
-0.0 0.0 0.0
-1.0 0.0 0.0
-1.0 1.0 0.0
-0.0 1.0 0.0
-2.0 0.0 0.0
-2.0 1.0 0.0
-$EndNodes
-$Elements
-1 2 1 2
-2 1 3 2
-1 1 2 3 4
-2 2 5 6 3
-$EndElements
-```
-
-## Element Types
-
-All formats use the same element type numbering:
-
-| Type | Name | Nodes | Dimension |
-|------|------|-------|-----------|
-| 1 | Line | 2 | 1D |
-| 2 | Triangle | 3 | 2D |
-| 3 | Quadrangle | 4 | 2D |
-| 4 | Tetrahedron | 4 | 3D |
-| 5 | Hexahedron | 8 | 3D |
-| 6 | Prism | 6 | 3D |
-| 7 | Pyramid | 5 | 3D |
-| 8 | Line (3-node) | 3 | 1D |
-| 9 | Triangle (6-node) | 6 | 2D |
-| 10 | Quadrangle (9-node) | 9 | 2D |
-| 11 | Tetrahedron (10-node) | 10 | 3D |
-| 15 | Point | 1 | 0D |
-| ... | Higher-order elements | ... | ... |
-
-See the [Gmsh documentation](https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format) for the complete list.
-
-## Version Detection
-
-gmshparser automatically detects the file format version:
+## Check the detected format
 
 ```python
 import gmshparser
 
 mesh = gmshparser.parse("mesh.msh")
-version = mesh.get_version()
-
-if version == 1.0:
-    print("Legacy MSH 1.0 format")
-elif version >= 2.0 and version < 3.0:
-    print("Standard MSH 2.x format")
-elif version >= 4.0:
-    print("Modern MSH 4.x format")
+print(mesh.get_version())
+print(mesh.is_ascii())
 ```
 
-### Detection Algorithm
+## Test coverage
 
-1. Read first line of file
-2. If line is `$MeshFormat`: Parse version from next line
-3. If line is `$NOD`: Assume MSH 1.0
-4. Otherwise: Error (unsupported format)
-
-## Format Compatibility
-
-### gmshparser → gmshparser
-
-All supported versions can be read and processed with the same API:
-
-```python
-# Same code works for all versions
-for entity in mesh.get_node_entities():
-    for node in entity.get_nodes():
-        print(node.get_tag(), node.get_coordinates())
-```
-
-### Gmsh → gmshparser
-
-gmshparser can read all mesh files generated by:
-
-- Gmsh 1.x (MSH 1.0)
-- Gmsh 2.x (MSH 2.0, 2.1, 2.2)
-- Gmsh 4.x (MSH 4.0, 4.1)
-
-### Limitations
-
-- **Binary format**: Not supported (ASCII only)
-- **Compressed format**: Not supported
-- **Post-processing data**: Node/element data sections not parsed (but can be added if needed)
-- **Periodic entities**: Not explicitly handled
-
-## Converting Between Versions
-
-To convert between formats, use Gmsh itself:
-
-```bash
-# Convert to MSH 2.2
-gmsh input.msh -format msh22 -o output.msh
-
-# Convert to MSH 4.1
-gmsh input.msh -format msh41 -o output.msh
-```
-
-Or in Python with gmshparser:
-
-```python
-# Read any version
-mesh = gmshparser.parse("input.msh")
-
-# Extract and rewrite (would need custom writer)
-# Note: gmshparser currently only reads, not writes
-```
-
-## Testing
-
-gmshparser is tested against real mesh files for all supported versions:
-
-- 10+ test files covering all versions
-- Elements from 0D (points) to 3D (tetrahedra)
-- Various mesh complexities
-- 100% success rate on test suite
-
-See the [Test Results](../developer-guide/test-results.md) for details.
-
-## Future Support
-
-Potential future additions:
-
-- Binary format support
-- Post-processing data sections
-- MSH format writing (currently read-only)
-- Compressed file support
-
-## References
-
-- [Official Gmsh MSH Format Documentation](https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format)
-- [Gmsh Website](https://gmsh.info/)
-- [Gmsh GitLab Repository](https://gitlab.onelab.info/gmsh/gmsh)
-
-## Next Steps
-
-- Try parsing different format versions
-- Check the [API Reference](../api/overview.md)
-- Learn about [Writing Custom Parsers](../developer-guide/writing-parsers.md)
+Repository test data includes files for each supported version family. Exact
+test and coverage totals are intentionally not duplicated here; the current
+GitHub Actions run is authoritative. See [Test Results](../developer-guide/test-results.md).

--- a/docs/user-guide/visualization.md
+++ b/docs/user-guide/visualization.md
@@ -1,336 +1,114 @@
 # Visualization
 
-gmshparser includes helper functions for visualizing 2D meshes using matplotlib.
+gmshparser itself has no plotting dependency. The helper functions in
+`gmshparser.helpers` prepare 2D mesh data for optional matplotlib use.
 
-!!! note
-    Visualization requires matplotlib. Install it with:
-    ```bash
-    pip install matplotlib
-    ```
-
-## Quick Start
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-
-# Parse mesh
-mesh = gmshparser.parse("mesh.msh")
-
-# Extract triangle data
-X, Y, T = gmshparser.helpers.get_triangles(mesh)
-
-# Plot
-plt.triplot(X, Y, T, 'k-', linewidth=0.5)
-plt.axis('equal')
-plt.show()
-```
-
-## Visualizing Triangular Meshes
-
-The `get_triangles()` helper extracts triangular elements:
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_triangles
-
-mesh = gmshparser.parse("data/example_mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-plt.figure(figsize=(10, 8))
-plt.triplot(X, Y, T, color='black', linewidth=0.5)
-plt.title(f"Triangular Mesh ({len(T)} triangles)")
-plt.xlabel("X")
-plt.ylabel("Y")
-plt.axis('equal')
-plt.grid(True, alpha=0.3)
-plt.tight_layout()
-plt.savefig("triangle_mesh.png", dpi=300)
-plt.show()
-```
-
-## Visualizing Quadrilateral Meshes
-
-For meshes with quadrilateral elements:
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_quads
-
-mesh = gmshparser.parse("quad_mesh.msh")
-X, Y, Q = get_quads(mesh)
-
-fig, ax = plt.subplots(figsize=(10, 8))
-
-# Plot each quad
-for quad in Q:
-    nodes = quad
-    x_coords = [X[n-1] for n in nodes] + [X[nodes[0]-1]]  # Close the quad
-    y_coords = [Y[n-1] for n in nodes] + [Y[nodes[0]-1]]
-    ax.plot(x_coords, y_coords, 'k-', linewidth=0.5)
-
-# Plot nodes
-ax.plot(X, Y, 'ro', markersize=3, label='Nodes')
-
-ax.set_title(f"Quadrilateral Mesh ({len(Q)} quads)")
-ax.set_xlabel("X")
-ax.set_ylabel("Y")
-ax.axis('equal')
-ax.grid(True, alpha=0.3)
-ax.legend()
-plt.tight_layout()
-plt.savefig("quad_mesh.png", dpi=300)
-plt.show()
-```
-
-## Visualizing Mixed Meshes
-
-For meshes containing both triangles and quads:
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_elements_2d
-
-mesh = gmshparser.parse("mixed_mesh.msh")
-X, Y, triangles, quads = get_elements_2d(mesh)
-
-fig, ax = plt.subplots(figsize=(12, 10))
-
-# Plot triangles
-if triangles:
-    ax.triplot(X, Y, triangles, 'b-', linewidth=0.5, label='Triangles')
-
-# Plot quads
-for quad in quads:
-    x_coords = [X[n-1] for n in quad] + [X[quad[0]-1]]
-    y_coords = [Y[n-1] for n in quad] + [Y[quad[0]-1]]
-    ax.plot(x_coords, y_coords, 'r-', linewidth=0.5)
-
-# Add custom legend for quads
-from matplotlib.lines import Line2D
-handles = [Line2D([0], [0], color='b', linewidth=0.5, label='Triangles'),
-           Line2D([0], [0], color='r', linewidth=0.5, label='Quads')]
-ax.legend(handles=handles)
-
-ax.set_title(f"Mixed Mesh ({len(triangles)} triangles, {len(quads)} quads)")
-ax.set_xlabel("X")
-ax.set_ylabel("Y")
-ax.axis('equal')
-ax.grid(True, alpha=0.3)
-plt.tight_layout()
-plt.savefig("mixed_mesh.png", dpi=300)
-plt.show()
-```
-
-## Advanced Plotting Options
-
-### Add Node Labels
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_triangles
-
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-fig, ax = plt.subplots(figsize=(12, 10))
-ax.triplot(X, Y, T, 'k-', linewidth=0.5)
-
-# Label nodes
-for i, (x, y) in enumerate(zip(X, Y), start=1):
-    ax.text(x, y, str(i), fontsize=8, ha='center', va='center',
-            bbox=dict(boxstyle='round,pad=0.3', facecolor='white', alpha=0.7))
-
-ax.set_title("Mesh with Node Labels")
-ax.axis('equal')
-plt.tight_layout()
-plt.show()
-```
-
-### Add Element Labels
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-import numpy as np
-from gmshparser.helpers import get_triangles
-
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-fig, ax = plt.subplots(figsize=(12, 10))
-ax.triplot(X, Y, T, 'k-', linewidth=0.5)
-
-# Label elements at their centroids
-for i, tri in enumerate(T, start=1):
-    x_center = np.mean([X[n] for n in tri])
-    y_center = np.mean([Y[n] for n in tri])
-    ax.text(x_center, y_center, str(i), fontsize=8, ha='center', va='center',
-            color='red')
-
-ax.set_title("Mesh with Element Labels")
-ax.axis('equal')
-plt.tight_layout()
-plt.show()
-```
-
-### Color by Element Property
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-import numpy as np
-from gmshparser.helpers import get_triangles
-
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-# Create some artificial property (e.g., element area)
-areas = []
-for tri in T:
-    x_coords = [X[n] for n in tri]
-    y_coords = [Y[n] for n in tri]
-    # Simple area calculation
-    area = 0.5 * abs((x_coords[1]-x_coords[0])*(y_coords[2]-y_coords[0]) - 
-                     (x_coords[2]-x_coords[0])*(y_coords[1]-y_coords[0]))
-    areas.append(area)
-
-fig, ax = plt.subplots(figsize=(12, 10))
-tpc = ax.tripcolor(X, Y, T, facecolors=areas, edgecolors='k', linewidth=0.5)
-fig.colorbar(tpc, ax=ax, label='Element Area')
-ax.set_title("Mesh Colored by Element Area")
-ax.axis('equal')
-plt.tight_layout()
-plt.show()
-```
-
-## Exporting Figures
-
-### High-Resolution PNG
-
-```python
-plt.savefig("mesh.png", dpi=300, bbox_inches='tight')
-```
-
-### Vector Graphics (PDF/SVG)
-
-```python
-plt.savefig("mesh.pdf", bbox_inches='tight')  # PDF
-plt.savefig("mesh.svg", bbox_inches='tight')  # SVG
-```
-
-### Multiple Formats
-
-```python
-for fmt in ['png', 'pdf', 'svg']:
-    plt.savefig(f"mesh.{fmt}", dpi=300, bbox_inches='tight')
-```
-
-## Complete Example Script
-
-Here's a complete example that creates a publication-quality figure:
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_triangles
-
-# Parse mesh
-mesh = gmshparser.parse("data/example_mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-# Create figure with publication settings
-plt.rcParams['font.size'] = 12
-plt.rcParams['font.family'] = 'serif'
-plt.rcParams['lines.linewidth'] = 0.5
-
-fig, ax = plt.subplots(figsize=(8, 6))
-
-# Plot mesh
-ax.triplot(X, Y, T, color='black', linewidth=0.5)
-
-# Styling
-ax.set_xlabel('X coordinate [m]', fontsize=14)
-ax.set_ylabel('Y coordinate [m]', fontsize=14)
-ax.set_title(f'Finite Element Mesh\n{len(T)} triangular elements', fontsize=16)
-ax.axis('equal')
-ax.grid(True, alpha=0.3, linestyle='--')
-ax.set_axisbelow(True)
-
-# Add statistics
-stats_text = f"Nodes: {len(X)}\nElements: {len(T)}"
-ax.text(0.02, 0.98, stats_text, transform=ax.transAxes,
-        verticalalignment='top', bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5))
-
-plt.tight_layout()
-plt.savefig('publication_mesh.png', dpi=300, bbox_inches='tight')
-plt.savefig('publication_mesh.pdf', bbox_inches='tight')
-plt.show()
-
-print("Figures saved: publication_mesh.png, publication_mesh.pdf")
-```
-
-## Interactive Visualization
-
-For interactive exploration:
-
-```python
-import gmshparser
-import matplotlib.pyplot as plt
-from gmshparser.helpers import get_triangles
-
-mesh = gmshparser.parse("mesh.msh")
-X, Y, T = get_triangles(mesh)
-
-plt.figure(figsize=(12, 10))
-plt.triplot(X, Y, T, 'k-', linewidth=0.5)
-plt.axis('equal')
-plt.title("Interactive Mesh (use zoom/pan tools)")
-
-# Enable interactive mode
-plt.ion()
-plt.show()
-
-# Keep window open
-input("Press Enter to close...")
-```
-
-## Troubleshooting
-
-### matplotlib Not Found
+Install matplotlib:
 
 ```bash
-pip install matplotlib
+uv add matplotlib
 ```
 
-### Empty Plot
+For a repository checkout:
 
-Check that your mesh contains 2D elements:
+```bash
+uv sync --group visualization
+```
+
+## Triangular meshes
+
+`get_triangles()` returns `(X, Y, T)`, where `T` contains zero-based indices
+into `X` and `Y`:
 
 ```python
+import gmshparser
+import matplotlib.pyplot as plt
+
 mesh = gmshparser.parse("mesh.msh")
-print(f"Element entities: {mesh.get_number_of_element_entities()}")
-for entity in mesh.get_element_entities():
-    print(f"Element type: {entity.get_element_type()}")
+X, Y, triangles = gmshparser.helpers.get_triangles(mesh)
+
+plt.triplot(X, Y, triangles, color="black", linewidth=0.5)
+plt.axis("equal")
+plt.show()
 ```
 
-### Memory Issues with Large Meshes
+Only three-node triangular elements (Gmsh type 2) are included.
 
-For very large meshes, plot only a subset:
+## Quadrilateral meshes
+
+`get_quads()` also returns zero-based connectivity:
 
 ```python
-X, Y, T = get_triangles(mesh)
-# Plot only first 1000 elements
-T_subset = T[:1000]
-plt.triplot(X, Y, T_subset, 'k-')
+import gmshparser
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+
+mesh = gmshparser.parse("quad_mesh.msh")
+X, Y, quads = gmshparser.helpers.get_quads(mesh)
+
+figure, axes = plt.subplots()
+for quad in quads:
+    coordinates = [(X[index], Y[index]) for index in quad]
+    axes.add_patch(Polygon(coordinates, fill=False, edgecolor="black"))
+
+axes.autoscale_view()
+axes.set_aspect("equal")
+plt.show()
 ```
 
-## Next Steps
+Only four-node quadrilateral elements (Gmsh type 3) are included.
 
-- Check the [API Reference](../api/helpers.md) for helper functions
-- Learn about [Supported Formats](supported-formats.md)
-- View [example scripts](https://github.com/ahojukka5/gmshparser/tree/master/examples)
+## Mixed triangle and quadrilateral meshes
+
+`get_elements_2d()` has a different return shape: it returns a dictionary and
+retains original Gmsh node tags in the connectivity lists.
+
+```python
+import gmshparser
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+
+mesh = gmshparser.parse("mixed_mesh.msh")
+data = gmshparser.helpers.get_elements_2d(mesh)
+
+nodes = data["nodes"]
+triangles = data["triangles"]
+quads = data["quads"]
+
+figure, axes = plt.subplots()
+
+for triangle in triangles:
+    coordinates = [nodes[node_tag] for node_tag in triangle]
+    axes.add_patch(Polygon(coordinates, fill=False, edgecolor="black"))
+
+for quad in quads:
+    coordinates = [nodes[node_tag] for node_tag in quad]
+    axes.add_patch(Polygon(coordinates, fill=False, edgecolor="black"))
+
+axes.autoscale_view()
+axes.set_aspect("equal")
+plt.show()
+```
+
+## Node and element labels
+
+The triangle helper connectivity refers to positions in `X` and `Y`, not to
+original Gmsh node tags. Label the plotted positions accordingly:
+
+```python
+for index, (x, y) in enumerate(zip(X, Y)):
+    axes.text(x, y, str(index))
+```
+
+To preserve original node tags, use `get_elements_2d()` and its `nodes`
+dictionary instead.
+
+## Large meshes
+
+All helpers construct Python lists and load their result in memory. For dense
+meshes, plotting every edge may be slow and visually unhelpful. Consider
+plotting only selected entities or a subset of elements.
+
+## API reference
+
+See [Helpers API](../api/helpers.md) for the exact return values of each helper.

--- a/examples/visualize_quads.py
+++ b/examples/visualize_quads.py
@@ -1,98 +1,98 @@
-"""Example: Visualize quadrilateral mesh using matplotlib.
+"""Visualize quadrilateral and mixed 2D meshes with matplotlib."""
 
-This example demonstrates how to visualize a mesh containing quadrilateral
-elements using gmshparser and matplotlib.
-"""
+from pathlib import Path
+
+import matplotlib.pyplot as plt
 
 import gmshparser
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
 
 
-def visualize_quads_simple():
-    """Simple quad visualization using get_quads()."""
-    # Parse mesh file
-    mesh = gmshparser.parse("../data/testmesh_v2_0.msh")
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TESTDATA = REPOSITORY_ROOT / "testdata"
 
-    # Extract quad elements
-    X, Y, Q = gmshparser.helpers.get_quads(mesh)
 
-    # Create figure
-    fig, ax = plt.subplots(figsize=(8, 6))
+def visualize_quads_simple() -> None:
+    """Visualize the quadrilateral MSH 2.0 test mesh."""
+    mesh = gmshparser.parse(str(TESTDATA / "simple" / "testmesh_v2_0.msh"))
+    x_coordinates, y_coordinates, quads = gmshparser.helpers.get_quads(mesh)
 
-    # Plot each quad as a polygon
-    for quad in Q:
-        coords = [[X[i], Y[i]] for i in quad]
-        coords.append(coords[0])  # Close the polygon
-        xs, ys = zip(*coords)
-        ax.plot(xs, ys, "k-", linewidth=1.5)
+    _, axes = plt.subplots(figsize=(8, 6))
 
-    # Plot nodes
-    ax.plot(X, Y, "ro", markersize=8)
+    for quad in quads:
+        coordinates = [
+            (x_coordinates[index], y_coordinates[index]) for index in quad
+        ]
+        coordinates.append(coordinates[0])
+        x_values, y_values = zip(*coordinates)
+        axes.plot(x_values, y_values, "k-", linewidth=1.5)
 
-    # Add node labels
-    for i, (x, y) in enumerate(zip(X, Y)):
-        ax.text(x, y, f" {i}", fontsize=10, verticalalignment="bottom")
+    axes.plot(x_coordinates, y_coordinates, "ro", markersize=8)
 
-    ax.set_aspect("equal")
-    ax.set_title("Quadrilateral Mesh Visualization")
-    ax.set_xlabel("X")
-    ax.set_ylabel("Y")
-    ax.grid(True, alpha=0.3)
+    for index, (x_value, y_value) in enumerate(
+        zip(x_coordinates, y_coordinates)
+    ):
+        axes.text(
+            x_value,
+            y_value,
+            f" {index}",
+            fontsize=10,
+            verticalalignment="bottom",
+        )
+
+    axes.set_aspect("equal")
+    axes.set_title("Quadrilateral Mesh Visualization")
+    axes.set_xlabel("X")
+    axes.set_ylabel("Y")
+    axes.grid(True, alpha=0.3)
     plt.tight_layout()
     plt.savefig("quad_mesh_simple.png", dpi=150)
     print("Saved: quad_mesh_simple.png")
 
 
-def visualize_mixed_mesh():
-    """Visualize mesh with both triangles and quads."""
-    # Parse mesh file
-    mesh = gmshparser.parse("../data/test_from_internet/mixed_v2_0.msh")
-
-    # Extract all 2D elements
+def visualize_mixed_mesh() -> None:
+    """Visualize a mesh containing both triangles and quadrilaterals."""
+    mesh = gmshparser.parse(
+        str(TESTDATA / "complex" / "test_from_internet" / "mixed_v2_0.msh")
+    )
     data = gmshparser.helpers.get_elements_2d(mesh)
     nodes = data["nodes"]
 
-    # Create figure
-    fig, ax = plt.subplots(figsize=(10, 6))
+    _, axes = plt.subplots(figsize=(10, 6))
 
-    # Plot triangles in blue
-    for tri in data["triangles"]:
-        coords = [(nodes[nid][0], nodes[nid][1]) for nid in tri]
-        coords.append(coords[0])  # Close the polygon
-        xs, ys = zip(*coords)
-        ax.plot(
-            xs,
-            ys,
+    for triangle in data["triangles"]:
+        coordinates = [nodes[node_tag] for node_tag in triangle]
+        coordinates.append(coordinates[0])
+        x_values, y_values = zip(*coordinates)
+        axes.plot(
+            x_values,
+            y_values,
             "b-",
             linewidth=1.5,
-            label="Triangle" if tri == data["triangles"][0] else "",
+            label="Triangle" if triangle == data["triangles"][0] else "",
         )
 
-    # Plot quads in red
     for quad in data["quads"]:
-        coords = [(nodes[nid][0], nodes[nid][1]) for nid in quad]
-        coords.append(coords[0])  # Close the polygon
-        xs, ys = zip(*coords)
-        ax.plot(
-            xs,
-            ys,
+        coordinates = [nodes[node_tag] for node_tag in quad]
+        coordinates.append(coordinates[0])
+        x_values, y_values = zip(*coordinates)
+        axes.plot(
+            x_values,
+            y_values,
             "r-",
             linewidth=1.5,
             label="Quad" if quad == data["quads"][0] else "",
         )
 
-    # Plot nodes
-    X = [nodes[nid][0] for nid in data["node_ids"]]
-    Y = [nodes[nid][1] for nid in data["node_ids"]]
-    ax.plot(X, Y, "ko", markersize=6)
+    x_coordinates = [nodes[node_tag][0] for node_tag in data["node_ids"]]
+    y_coordinates = [nodes[node_tag][1] for node_tag in data["node_ids"]]
+    axes.plot(x_coordinates, y_coordinates, "ko", markersize=6)
 
-    ax.set_aspect("equal")
-    ax.set_title("Mixed Mesh: Triangles and Quadrilaterals")
-    ax.set_xlabel("X")
-    ax.set_ylabel("Y")
-    ax.grid(True, alpha=0.3)
-    ax.legend()
+    axes.set_aspect("equal")
+    axes.set_title("Mixed Mesh: Triangles and Quadrilaterals")
+    axes.set_xlabel("X")
+    axes.set_ylabel("Y")
+    axes.grid(True, alpha=0.3)
+    axes.legend()
     plt.tight_layout()
     plt.savefig("mixed_mesh.png", dpi=150)
     print("Saved: mixed_mesh.png")

--- a/examples/visualize_quads.py
+++ b/examples/visualize_quads.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 
 import gmshparser
 
-
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 TESTDATA = REPOSITORY_ROOT / "testdata"
 

--- a/examples/visualize_quads.py
+++ b/examples/visualize_quads.py
@@ -19,18 +19,14 @@ def visualize_quads_simple() -> None:
     _, axes = plt.subplots(figsize=(8, 6))
 
     for quad in quads:
-        coordinates = [
-            (x_coordinates[index], y_coordinates[index]) for index in quad
-        ]
+        coordinates = [(x_coordinates[index], y_coordinates[index]) for index in quad]
         coordinates.append(coordinates[0])
         x_values, y_values = zip(*coordinates)
         axes.plot(x_values, y_values, "k-", linewidth=1.5)
 
     axes.plot(x_coordinates, y_coordinates, "ro", markersize=8)
 
-    for index, (x_value, y_value) in enumerate(
-        zip(x_coordinates, y_coordinates)
-    ):
+    for index, (x_value, y_value) in enumerate(zip(x_coordinates, y_coordinates)):
         axes.text(
             x_value,
             y_value,

--- a/gmshparser/__init__.py
+++ b/gmshparser/__init__.py
@@ -3,37 +3,32 @@ from .main_parser import MainParser
 from .version_manager import VersionManager, MshFormatVersion
 from . import helpers
 
-__version__ = "0.2.0"
+__version__ = "0.3.1"
 __author__ = "Jukka Aho <ahojukka5@gmail.com>"
 
 
 def parse(filename: str) -> Mesh:
-    """Parse Gmsh .msh file and return `Mesh` object.
+    """Parse an ASCII Gmsh MSH file and return a :class:`Mesh` object.
 
-    This function automatically detects the MSH format version and uses
-    the appropriate parsers for that version.
-
-    Supported versions:
-    - MSH 2.2 (legacy format)
-    - MSH 4.0
-    - MSH 4.1 (current format)
+    The file format version is detected automatically. Supported versions are
+    MSH 1.0, 2.0, 2.1, 2.2, 4.0, and 4.1.
 
     Parameters
     ----------
     filename : str
-        Path to the .msh file to parse
+        Path to the MSH file.
 
     Returns
     -------
     Mesh
-        Parsed mesh object containing nodes, elements, and metadata
+        Parsed mesh containing nodes, elements, and format metadata.
 
     Raises
     ------
-    ValueError
-        If the file version is not supported
     FileNotFoundError
-        If the file does not exist
+        If the file does not exist.
+    ValueError
+        If the MSH version is unsupported or the input is invalid.
     """
     mesh = Mesh()
     mesh.set_name(filename)

--- a/gmshparser/cli.py
+++ b/gmshparser/cli.py
@@ -1,16 +1,19 @@
-import sys
-import argparse
-from . import parse
+"""Command-line helpers for inspecting parsed meshes."""
 
-"""gmshparser cli provides some helpers to convert mesh to another format."""
+import argparse
+import sys
+
+from . import __version__, parse
 
 
 def info(mesh, file) -> None:
+    """Print the mesh summary."""
     print("---- MESH SUMMARY ----", file=file)
     print(mesh, file=file)
 
 
 def nodes(mesh, file) -> None:
+    """Print all nodes in a simple line-oriented format."""
     print(mesh.get_number_of_nodes(), file=file)
     for entity in mesh.get_node_entities():
         for node in entity.get_nodes():
@@ -20,6 +23,7 @@ def nodes(mesh, file) -> None:
 
 
 def elements(mesh, file) -> None:
+    """Print all elements in a simple line-oriented format."""
     print(mesh.get_number_of_elements(), file=file)
     for entity in mesh.get_element_entities():
         eltype = entity.get_element_type()
@@ -30,10 +34,16 @@ def elements(mesh, file) -> None:
 
 
 def main(argv=None, file=sys.stdout) -> None:
-    parser = argparse.ArgumentParser()
+    """Run the gmshparser command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Inspect an ASCII Gmsh MSH file."
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
     choices = {"info": info, "nodes": nodes, "elements": elements}
-    parser.add_argument("filename", action="store")
-    parser.add_argument("action", choices=list(choices.keys()))
-    args = parser.parse_args(argv or sys.argv[1:])
+    parser.add_argument("filename")
+    parser.add_argument("action", choices=list(choices))
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     mesh = parse(args.filename)
     choices[args.action](mesh, file)

--- a/gmshparser/cli.py
+++ b/gmshparser/cli.py
@@ -37,7 +37,9 @@ def main(argv=None, file=sys.stdout) -> None:
     """Run the gmshparser command-line interface."""
     parser = argparse.ArgumentParser(description="Inspect an ASCII Gmsh MSH file.")
     parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     choices = {"info": info, "nodes": nodes, "elements": elements}
     parser.add_argument("filename")

--- a/gmshparser/cli.py
+++ b/gmshparser/cli.py
@@ -35,9 +35,7 @@ def elements(mesh, file) -> None:
 
 def main(argv=None, file=sys.stdout) -> None:
     """Run the gmshparser command-line interface."""
-    parser = argparse.ArgumentParser(
-        description="Inspect an ASCII Gmsh MSH file."
-    )
+    parser = argparse.ArgumentParser(description="Inspect an ASCII Gmsh MSH file.")
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )

--- a/gmshparser/cli.py
+++ b/gmshparser/cli.py
@@ -35,7 +35,10 @@ def elements(mesh, file) -> None:
 
 def main(argv=None, file=sys.stdout) -> None:
     """Run the gmshparser command-line interface."""
-    parser = argparse.ArgumentParser(description="Inspect an ASCII Gmsh MSH file.")
+    parser = argparse.ArgumentParser(
+        prog="gmshparser",
+        description="Inspect an ASCII Gmsh MSH file.",
+    )
     parser.add_argument(
         "--version",
         action="version",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,14 +1,13 @@
 site_name: gmshparser
-site_description: A lightweight Python package for parsing Gmsh .msh mesh files
+site_description: A lightweight Python package for parsing ASCII Gmsh MSH files
 site_author: Jukka Aho
-site_url: https://gmshparser.readthedocs.io
+site_url: https://ahojukka5.github.io/gmshparser/
 repo_url: https://github.com/ahojukka5/gmshparser
 repo_name: ahojukka5/gmshparser
 
 theme:
   name: material
   palette:
-    # Light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: indigo
@@ -16,7 +15,6 @@ theme:
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    # Dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: indigo
@@ -39,7 +37,7 @@ plugins:
       handlers:
         python:
           options:
-            docstring_style: google
+            docstring_style: numpy
             show_source: true
             show_root_heading: true
             show_symbol_type_heading: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,21 @@
 [project]
 name = "gmshparser"
 version = "0.3.1"
-description = "gmshparser is a lightweight, 100 % tested and well documented package that parses Gmsh ascii file format (.msh)"
+description = "A lightweight, dependency-free Python package for parsing ASCII Gmsh MSH files"
 authors = [
     { name = "Jukka Aho", email = "ahojukka5@gmail.com" },
 ]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []
+
+[project.scripts]
+gmshparser = "gmshparser.cli:main"
+
+[project.urls]
+Documentation = "https://ahojukka5.github.io/gmshparser/"
+Issues = "https://github.com/ahojukka5/gmshparser/issues"
+Repository = "https://github.com/ahojukka5/gmshparser"
 
 [dependency-groups]
 test = [

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,215 +1,72 @@
 # Test Data
 
-This directory contains mesh files used for testing gmshparser across different MSH format versions.
+This directory contains ASCII Gmsh MSH files used by the automated tests and
+manual examples.
 
-## Directory Structure
+## Organization
 
-```
-testdata/
-├── README.md           # This file
-├── simple/            # Simple test meshes for unit tests
-├── complex/           # Complex meshes with mixed elements
-└── large/             # Large meshes (Git LFS)
-```
+- `simple/` contains small, purpose-built meshes for version and parser tests.
+- `complex/` contains larger or externally sourced regression cases and their
+  attribution notes.
+- `large/` contains the larger example mesh used by visualization and
+  performance-oriented checks.
 
-## File Organization
+The repository currently stores these files directly in Git. Git LFS is not
+configured.
 
-### simple/
+## Supported-version fixtures
 
-Small, straightforward meshes for basic testing:
+The simple fixtures cover the supported format families, including MSH 1.0,
+MSH 2.x, and MSH 4.x. Tests should refer to the exact committed filename rather
+than assuming a generated file is available.
 
-- `testmesh_v1_0.msh` - MSH 1.0 format, 6 nodes, 2 quads
-- `testmesh_v2_0.msh` - MSH 2.0 format, 6 nodes, 2 quads
-- `testmesh_v2_1.msh` - MSH 2.1 format with physical groups
-- `testmesh.msh` - MSH 4.1 format, 6 nodes, 2 quads
+## Adding a mesh
 
-### complex/
+Prefer the smallest file that reproduces the behavior under test.
 
-Meshes with multiple element types and features:
+1. Place a small synthetic fixture in `simple/`.
+2. Place a real-world or multi-feature regression case in a suitable
+   `complex/` subdirectory.
+3. Include the source `.geo` file when it is available and useful.
+4. Add attribution and licensing information for externally sourced data.
+5. Add a focused pytest test that states the expected version, counts, or
+   parser behavior.
 
-- `complex_v1_0.msh` - MSH 1.0 with points, lines, triangles, quads, tets
-- `mixed_v2_0.msh` - MSH 2.0 with mixed 2D elements
-- `physical_v2_1.msh` - MSH 2.1 with physical group metadata
-- `entities_v4_1.msh` - MSH 4.1 demonstrating entity structure
-
-### large/
-
-Large meshes for performance testing (stored with Git LFS):
-
-- `example_mesh.msh` - MSH 4.1, 197 nodes, 396 triangular elements
-
-## Contributing Test Data
-
-We welcome contributions of mesh files! If you have interesting test cases:
-
-### What We Need
-
-- **Various MSH versions**: Especially edge cases in different versions
-- **Different element types**: High-order elements, 3D elements, mixed meshes
-- **Real-world examples**: Actual meshes from FEM simulations
-- **Edge cases**: Unusual geometries, boundary conditions
-
-### How to Contribute
-
-1. **For small files** (< 1 MB):
-
-   ```bash
-   # Add file to appropriate directory
-   cp your_mesh.msh testdata/simple/  # or complex/
-   
-   # Commit and push
-   git add testdata/simple/your_mesh.msh
-   git commit -m "Add test mesh: your_mesh.msh"
-   ```
-
-2. **For large files** (> 1 MB):
-
-   Large files should use Git LFS to avoid bloating the repository.
-
-   ```bash
-   # Install Git LFS (if not already installed)
-   git lfs install
-   
-   # Track large mesh files
-   git lfs track "testdata/large/*.msh"
-   
-   # Add .gitattributes
-   git add .gitattributes
-   
-   # Add your large mesh file
-   cp your_large_mesh.msh testdata/large/
-   git add testdata/large/your_large_mesh.msh
-   
-   # Commit and push
-   git commit -m "Add large test mesh: your_large_mesh.msh"
-   git push
-   ```
-
-### Include .geo Files
-
-If you have the Gmsh `.geo` files used to generate the meshes, please include them:
-
-```bash
-cp mesh.geo testdata/simple/
-git add testdata/simple/mesh.geo
-git commit -m "Add .geo file for test mesh"
-```
-
-This helps others understand how the mesh was created and regenerate it if needed.
-
-## File Naming Convention
-
-Use descriptive names that indicate:
-
-1. **Purpose**: `simple_`, `complex_`, `large_`
-2. **Format version**: `_v1_0`, `_v2_0`, `_v4_1`
-3. **Features**: `_mixed`, `_physical`, `_periodic`
-
-Examples:
-
-- `simple_quad_v2_0.msh`
-- `complex_mixed_3d_v4_1.msh`
-- `large_structural_mesh_v4_1.msh`
-
-## Git LFS Setup
-
-If you plan to add large files, set up Git LFS:
-
-### Installation
-
-**Linux:**
-
-```bash
-sudo apt-get install git-lfs  # Debian/Ubuntu
-sudo dnf install git-lfs      # Fedora
-```
-
-**macOS:**
-
-```bash
-brew install git-lfs
-```
-
-**Windows:**
-
-Download from [git-lfs.github.com](https://git-lfs.github.com/)
-
-### Initialize
-
-```bash
-cd /path/to/gmshparser
-git lfs install
-git lfs track "testdata/large/*.msh"
-git add .gitattributes
-git commit -m "Configure Git LFS for large mesh files"
-```
-
-### Verify
-
-```bash
-# Check tracked patterns
-git lfs track
-
-# Check LFS status
-git lfs status
-```
-
-## Testing Your Mesh
-
-After adding a mesh file, verify it works:
+Example:
 
 ```python
 import gmshparser
 
-# Parse your mesh
-mesh = gmshparser.parse("testdata/simple/your_mesh.msh")
 
-# Check basic properties
-print(f"Version: {mesh.get_version()}")
-print(f"Nodes: {mesh.get_number_of_nodes()}")
-print(f"Elements: {mesh.get_number_of_elements()}")
+def test_contributed_mesh():
+    mesh = gmshparser.parse("testdata/complex/example.msh")
 
-# Verify it parses correctly
-assert mesh.get_number_of_nodes() > 0
-assert mesh.get_number_of_elements() > 0
-```
-
-Add a test case:
-
-```python
-# In tests/test_contributed_meshes.py
-def test_your_mesh():
-    """Test parsing your_mesh.msh"""
-    mesh = gmshparser.parse("testdata/simple/your_mesh.msh")
     assert mesh.get_version() == 4.1
-    assert mesh.get_number_of_nodes() == 42
-    assert mesh.get_number_of_elements() == 80
+    assert mesh.get_number_of_nodes() > 0
+    assert mesh.get_number_of_elements() > 0
 ```
 
-## License and Attribution
+Do not document invented counts or files before they are committed and tested.
 
-By contributing mesh files, you agree that:
+## Large files
 
-1. You have the right to contribute the file
-2. The file can be used under the project's MIT license
-3. The file can be redistributed with gmshparser
+Avoid adding unnecessarily large meshes. If future fixtures become large enough
+to justify Git LFS, configure `.gitattributes` in the same change and update this
+README. Until then, do not describe files as LFS-managed.
 
-If your mesh file requires attribution, add details to this README:
+## External data
 
-### Attributions
+A contributed mesh must be redistributable under terms compatible with this
+repository. Record its source and any required attribution in a README next to
+the file.
 
-- `example_mesh.msh` - Created by Jukka Aho for testing purposes
-- `your_mesh.msh` - Contributed by Your Name, description of origin
+## Running tests
 
-## Current Test Coverage
+```bash
+uv sync
+uv run pytest
+```
 
-See [Test Results](../docs/developer-guide/test-results.md) for details on which formats and features are currently tested.
-
-## Questions?
-
-If you have questions about contributing test data:
-
-- Open a [GitHub issue](https://github.com/ahojukka5/gmshparser/issues)
-- Contact: <ahojukka5@gmail.com>
-
-Thank you for helping improve gmshparser! 🎉
+See [Test Results](../docs/developer-guide/test-results.md) for the current CI
+matrix and [Testing Guide](../docs/developer-guide/testing.md) for development
+commands.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ import os
 
 import pytest
 
-
 __content__ = """
 $MeshFormat
 4.1 0 8

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,9 @@ from gmshparser.cli import main
 from io import StringIO
 import os
 
+import pytest
+
+
 __content__ = """
 $MeshFormat
 4.1 0 8
@@ -51,11 +54,9 @@ def test_main(tmpdir):
     fh = tmpdir.join("mesh1.msh")
     fh.write(__content__.strip())
     filename = os.path.join(fh.dirname, fh.basename)
-    # We just check that there comes some print from functions to stdout
 
     output = StringIO()
     main([filename, "info"], output)
-    print(output.getvalue())
     assert len(output.getvalue()) > 100
 
     output = StringIO()
@@ -65,3 +66,11 @@ def test_main(tmpdir):
     output = StringIO()
     main([filename, "elements"], output)
     assert len(output.getvalue()) == 26
+
+
+def test_version(capsys):
+    with pytest.raises(SystemExit) as error:
+        main(["--version"])
+
+    assert error.value.code == 0
+    assert capsys.readouterr().out.strip() == "gmshparser 0.3.1"


### PR DESCRIPTION
## Summary

- rewrite README and MkDocs pages to match the current Python 3.12+, uv-based project
- document the actual ASCII MSH version support and current parser limitations
- correct CLI, visualization helper, parser architecture, testing, and test-data guidance
- point documentation metadata and badges to GitHub Pages and Codecov
- remove stale ReadTheDocs, Coveralls, Poetry-only, Git LFS, binary-format, and exact coverage claims

## Functional fixes discovered during the audit

- restore the packaged `gmshparser` console-script entry point
- synchronize `gmshparser.__version__` with project version 0.3.1
- add a real `gmshparser --version` option
- smoke-test the installed CLI from both wheel and source distributions

## Validation

GitHub Actions will run Black, flake8, pytest with coverage, Python 3.12–3.14, package builds, wheel/sdist CLI smoke tests, and the MkDocs documentation build.