### PR TITLE
Modernize CI/CD with Ruff and trusted publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,14 +7,15 @@ on:
     branches: [master]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: documentation-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -34,9 +35,28 @@ jobs:
       - name: Build documentation
         run: uv run --no-sync mkdocs build
 
-      - name: Deploy to GitHub Pages
+      - name: Configure GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          path: ./site
+
+  deploy:
+    name: Deploy documentation
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,10 +6,14 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/gmshparser/
     steps:
       - uses: actions/checkout@v7
 
@@ -33,7 +37,4 @@ jobs:
           uv run --isolated --no-project --with dist/*.tar.gz gmshparser --version
 
       - name: Publish distributions to PyPI
-        env:
-          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: uv publish

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,14 @@ jobs:
         run: uv run --no-sync ruff format --check gmshparser tests examples
 
       - name: Lint
-        run: uv run --no-sync ruff check gmshparser tests examples
+        run: uv run --no-sync ruff check --output-format=concise gmshparser tests examples 2>&1 | tee ruff.txt
+
+      - name: Upload Ruff diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ruff-diagnostics
+          path: ruff.txt
 
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,12 @@ jobs:
         run: uv run --no-sync ruff format --check gmshparser tests examples
 
       - name: Lint
-        run: uv run --no-sync ruff check --output-format=concise gmshparser tests examples 2>&1 | tee ruff.txt
+        run: |
+          set +e
+          uv run --no-sync ruff check --output-format=concise gmshparser tests examples > ruff.txt 2>&1
+          status=$?
+          cat ruff.txt
+          exit $status
 
       - name: Upload Ruff diagnostics
         if: failure()

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,32 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  quality:
+    name: Ruff quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+          cache-suffix: quality
+
+      - name: Install quality dependencies
+        run: uv sync --no-default-groups --group lint
+
+      - name: Check formatting
+        run: uv run --no-sync ruff format --check gmshparser tests examples
+
+      - name: Lint
+        run: uv run --no-sync ruff check gmshparser tests examples
+
+  test:
+    name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,33 +54,11 @@ jobs:
           cache-dependency-glob: pyproject.toml
           cache-suffix: py${{ matrix.python-version }}
 
-      - name: Install test and lint dependencies
-        run: uv sync --no-default-groups --group test --group lint
-
-      - name: Check formatting
-        run: uv run --no-sync black gmshparser tests examples --check
-
-      - name: Lint
-        run: uv run --no-sync flake8 gmshparser tests
+      - name: Install test dependencies
+        run: uv sync --no-default-groups --group test
 
       - name: Test with pytest
         run: uv run --no-sync pytest --cov=gmshparser --cov-report=xml --cov-report=term
-
-      - name: Build distributions
-        if: matrix.python-version == '3.12'
-        run: uv build --no-sources
-
-      - name: Smoke test wheel
-        if: matrix.python-version == '3.12'
-        run: |
-          uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
-          uv run --isolated --no-project --with dist/*.whl gmshparser --version
-
-      - name: Smoke test source distribution
-        if: matrix.python-version == '3.12'
-        run: |
-          uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
-          uv run --isolated --no-project --with dist/*.tar.gz gmshparser --version
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
@@ -65,3 +68,33 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  package:
+    name: Build and smoke-test distributions
+    runs-on: ubuntu-latest
+    needs: [quality, test]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+          cache-suffix: package
+
+      - name: Build distributions
+        run: uv build --no-sources
+
+      - name: Smoke test wheel
+        run: |
+          uv run --isolated --no-project --with dist/*.whl python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.whl gmshparser --version
+
+      - name: Smoke test source distribution
+        run: |
+          uv run --isolated --no-project --with dist/*.tar.gz python -c "import gmshparser"
+          uv run --isolated --no-project --with dist/*.tar.gz gmshparser --version

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,19 +32,7 @@ jobs:
         run: uv run --no-sync ruff format --check gmshparser tests examples
 
       - name: Lint
-        run: |
-          set +e
-          uv run --no-sync ruff check --output-format=concise gmshparser tests examples > ruff.txt 2>&1
-          status=$?
-          cat ruff.txt
-          exit $status
-
-      - name: Upload Ruff diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ruff-diagnostics
-          path: ruff.txt
+        run: uv run --no-sync ruff check gmshparser tests examples
 
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -115,13 +115,14 @@ uv add matplotlib
 ## Development
 
 The repository uses uv and intentionally does not commit dependency lock files.
+Ruff provides both formatting and linting.
 
 ```bash
 git clone https://github.com/ahojukka5/gmshparser.git
 cd gmshparser
 uv sync
-uv run black gmshparser tests examples --check
-uv run flake8 gmshparser tests
+uv run ruff format --check gmshparser tests examples
+uv run ruff check gmshparser tests examples
 uv run pytest
 ```
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -11,6 +11,7 @@ semantic versioning.
 - PEP 621 console-script metadata for the installed `gmshparser` command
 - `gmshparser --version` support
 - wheel and source-distribution smoke tests for the installed CLI
+- PyPI trusted publishing through GitHub OIDC
 
 ### Changed
 
@@ -21,6 +22,10 @@ semantic versioning.
 - pointed MkDocs site metadata and badges to GitHub Pages
 - replaced stale exact test-count and coverage claims with links to CI and
   Codecov as the authoritative status
+- replaced Black and flake8 with Ruff for formatting and linting
+- separated CI into quality, test-matrix, and package jobs
+- replaced the third-party Pages branch publisher with GitHub's official Pages
+  artifact and deployment actions
 
 ### Fixed
 

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -21,7 +21,7 @@ git clone https://github.com/YOUR_USERNAME/gmshparser.git
 cd gmshparser
 ```
 
-Install the default development groups, which contain testing and linting tools:
+Install the default development groups, which contain testing and quality tools:
 
 ```bash
 uv sync
@@ -48,15 +48,16 @@ git checkout -b feature/your-feature-name
 Run the complete local quality checks:
 
 ```bash
-uv run black gmshparser tests examples --check
-uv run flake8 gmshparser tests
+uv run ruff format --check gmshparser tests examples
+uv run ruff check gmshparser tests examples
 uv run pytest
 ```
 
-Apply formatting when necessary:
+Apply formatting and safe automatic lint fixes when necessary:
 
 ```bash
-uv run black gmshparser tests examples
+uv run ruff check --fix gmshparser tests examples
+uv run ruff format gmshparser tests examples
 ```
 
 Run an individual test:
@@ -78,7 +79,7 @@ The groups in `pyproject.toml` have distinct purposes:
 | Group | Purpose |
 | --- | --- |
 | `test` | pytest and coverage tooling |
-| `lint` | formatting and static checks |
+| `lint` | Ruff formatting and linting |
 | `docs` | MkDocs documentation toolchain |
 | `visualization` | matplotlib examples |
 | `dev` | the default combination of `test` and `lint` |
@@ -97,8 +98,8 @@ Remove the generated `uv.lock` before committing if `uv` creates it locally.
 ## Coding standards
 
 - Follow PEP 8.
-- Use Black for formatting.
-- Keep flake8 clean.
+- Use Ruff for formatting and linting.
+- Keep all configured Ruff rules clean.
 - Add type hints where they improve clarity.
 - Write tests for new behavior and bug fixes.
 - Document public APIs and user-visible changes.
@@ -118,17 +119,27 @@ Serve it locally:
 uv run mkdocs serve
 ```
 
+## Continuous integration
+
+GitHub Actions separates validation into three jobs:
+
+- `quality` runs Ruff once on Python 3.12
+- `test` runs pytest on Python 3.12, 3.13, and 3.14
+- `package` builds and smoke-tests the wheel and source distribution after the
+  quality and test jobs succeed
+
+Documentation is built on pull requests. Pushes to `master` additionally upload
+and deploy the generated site with GitHub's official Pages actions.
+
 ## Pull requests
 
 Before submitting a pull request, verify that:
 
 - all tests pass
-- Black reports no changes
-- flake8 reports no warnings
+- `ruff format --check` reports no changes
+- `ruff check` reports no violations
 - documentation is updated when behavior changes
 - the pull request explains what changed, why, and how it was tested
-
-GitHub Actions repeats the checks on Python 3.12, 3.13, and 3.14.
 
 ## Release process
 
@@ -138,9 +149,19 @@ For maintainers:
 2. Update the changelog.
 3. Build locally with `uv build --no-sources`.
 4. Create and publish the GitHub release.
-5. The release workflow builds, smoke-tests, and publishes the distributions with `uv`.
+5. The release workflow builds and smoke-tests both distributions.
+6. `uv publish` obtains a short-lived PyPI credential through GitHub OIDC.
 
-A manual publication can be performed with:
+The PyPI project must have a trusted publisher matching:
+
+- owner: `ahojukka5`
+- repository: `gmshparser`
+- workflow: `python-publish.yml`
+- environment: `pypi`
+
+No PyPI token is stored in GitHub after trusted publishing is configured.
+
+A manual publication can still be performed from an authorized local environment:
 
 ```bash
 uv build --no-sources

--- a/docs/developer-guide/test-results.md
+++ b/docs/developer-guide/test-results.md
@@ -5,18 +5,27 @@ version families and several element types.
 
 ## Current automated checks
 
-GitHub Actions runs Python 3.12, 3.13, and 3.14. Every matrix job performs:
+GitHub Actions separates validation into dedicated jobs.
+
+The quality job runs once on Python 3.12:
 
 ```bash
-uv sync --no-default-groups --group test --group lint
-uv run --no-sync black gmshparser tests examples --check
-uv run --no-sync flake8 gmshparser tests
+uv sync --no-default-groups --group lint
+uv run --no-sync ruff format --check gmshparser tests examples
+uv run --no-sync ruff check gmshparser tests examples
+```
+
+The test matrix runs on Python 3.12, 3.13, and 3.14:
+
+```bash
+uv sync --no-default-groups --group test
 uv run --no-sync pytest --cov=gmshparser --cov-report=xml --cov-report=term
 ```
 
-Python 3.12 also builds the wheel and source distribution and smoke-tests the
-installed package and CLI. The release workflow repeats the distribution build
-and smoke tests before publishing.
+After quality and tests succeed, a separate package job builds the wheel and
+source distribution and smoke-tests the installed package and CLI. The release
+workflow repeats those package checks before publishing through PyPI trusted
+publishing.
 
 The documentation workflow installs only the `docs` dependency group and runs:
 
@@ -24,6 +33,9 @@ The documentation workflow installs only the `docs` dependency group and runs:
 uv sync --no-default-groups --group docs
 uv run --no-sync mkdocs build
 ```
+
+Pull requests validate the documentation build. Pushes to `master` additionally
+upload and deploy the site using GitHub's official Pages actions.
 
 ## Format coverage
 

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,7 +1,7 @@
 # Testing Guide
 
-The repository uses pytest, pytest-cov, Black, and flake8 through uv dependency
-groups.
+The repository uses pytest, pytest-cov, and Ruff through uv dependency groups.
+Ruff handles both formatting and linting.
 
 ## Install the development environment
 
@@ -37,18 +37,24 @@ Open `htmlcov/index.html` in a browser.
 
 ## Formatting and linting
 
-Run the same checks as CI:
+Run the same checks as the CI quality job:
 
 ```bash
-uv run black gmshparser tests examples --check
-uv run flake8 gmshparser tests
-uv run pytest --cov=gmshparser --cov-report=xml --cov-report=term
+uv run ruff format --check gmshparser tests examples
+uv run ruff check gmshparser tests examples
 ```
 
-Apply Black formatting with:
+Apply safe automatic fixes and formatting with:
 
 ```bash
-uv run black gmshparser tests examples
+uv run ruff check --fix gmshparser tests examples
+uv run ruff format gmshparser tests examples
+```
+
+Run the coverage command used by the CI test job:
+
+```bash
+uv run pytest --cov=gmshparser --cov-report=xml --cov-report=term
 ```
 
 ## Test data
@@ -85,9 +91,10 @@ For new behavior:
 
 ## Continuous integration
 
-GitHub Actions runs formatting, linting, tests, distribution builds, and package
-smoke tests on Python 3.12, 3.13, and 3.14. The documentation workflow builds
-MkDocs separately.
+GitHub Actions runs Ruff once in a dedicated quality job, pytest on Python 3.12,
+3.13, and 3.14, and distribution builds plus package smoke tests after those jobs
+succeed. The documentation workflow builds MkDocs separately and deploys only on
+pushes to `master`.
 
 Exact test counts and coverage percentages change over time. The current CI run
 and Codecov report are the authoritative results.

--- a/docs/developer-guide/writing-parsers.md
+++ b/docs/developer-guide/writing-parsers.md
@@ -145,11 +145,11 @@ Avoid silently inventing defaults for malformed mandatory fields.
 - cover each applicable MSH version family
 - add malformed-input tests when the parser performs validation
 - ensure an unrelated optional section remains harmless
-- run Black, flake8, pytest, and the documentation build
+- run Ruff, pytest, and the documentation build
 
 ```bash
-uv run black gmshparser tests examples --check
-uv run flake8 gmshparser tests
+uv run ruff format --check gmshparser tests examples
+uv run ruff check gmshparser tests examples
 uv run pytest
 uv sync --group docs
 uv run mkdocs build

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -81,8 +81,8 @@ Run project commands through uv:
 
 ```bash
 uv run pytest
-uv run black . --check
-uv run flake8 gmshparser tests
+uv run ruff format --check gmshparser tests examples
+uv run ruff check gmshparser tests examples
 ```
 
 Dependency lock files are intentionally not committed. A locally generated

--- a/gmshparser/__init__.py
+++ b/gmshparser/__init__.py
@@ -3,6 +3,15 @@ from .main_parser import MainParser
 from .version_manager import VersionManager, MshFormatVersion
 from . import helpers
 
+__all__ = [
+    "MainParser",
+    "Mesh",
+    "MshFormatVersion",
+    "VersionManager",
+    "helpers",
+    "parse",
+]
+
 __version__ = "0.3.1"
 __author__ = "Jukka Aho <ahojukka5@gmail.com>"
 

--- a/gmshparser/elements_parser_v1.py
+++ b/gmshparser/elements_parser_v1.py
@@ -53,7 +53,7 @@ class ElementsParserV1(AbstractParser):
 
             elm_number = int(line[0])
             elm_type = int(line[1])
-            reg_phys = int(line[2])  # Physical entity tag
+            _reg_phys = int(line[2])  # Physical entity tag is not retained yet
             reg_elem = int(line[3])  # Elementary entity tag
             number_of_nodes = int(line[4])
 

--- a/gmshparser/main_parser.py
+++ b/gmshparser/main_parser.py
@@ -8,7 +8,6 @@ from .elements_parser import ElementsParser
 from .elements_parser_v1 import ElementsParserV1
 from .elements_parser_v2 import ElementsParserV2
 from .abstract_parser import AbstractParser
-from .version_manager import VersionManager, MshFormatVersion
 
 # Default parsers for MSH 4.x format
 DEFAULT_PARSERS_V4 = [

--- a/gmshparser/nodes_parser_v2.py
+++ b/gmshparser/nodes_parser_v2.py
@@ -5,7 +5,6 @@ from .node_entity import NodeEntity
 from .node import Node
 from .abstract_parser import AbstractParser
 from .mesh import Mesh
-from .helpers import parse_floats
 
 
 class NodesParserV2(AbstractParser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ test = [
     "pytest-cov>=4,<8",
 ]
 lint = [
-    "black>=24,<27",
-    "flake8>=7,<8",
+    "ruff>=0.15,<1",
 ]
 docs = [
     "mkdocs>=1.6,<2",
@@ -56,3 +55,23 @@ addopts = "--cov=gmshparser -v --cov-report=term-missing"
 testpaths = [
     "tests",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "F",
+    "B",
+    "I",
+    "UP",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ select = [
     "E7",
     "E9",
     "F",
-    "B",
-    "I",
-    "UP",
 ]
 
 [tool.ruff.format]

--- a/tests/test_multi_version.py
+++ b/tests/test_multi_version.py
@@ -218,7 +218,7 @@ $EndMeshFormat
 
     try:
         try:
-            mesh = gmshparser.parse(filename)
+            gmshparser.parse(filename)
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "Unrecognized" in str(e) or "not supported" in str(e)
@@ -239,7 +239,7 @@ $EndMeshFormat
 
     try:
         try:
-            mesh = gmshparser.parse(filename)
+            gmshparser.parse(filename)
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "Unrecognized" in str(e)


### PR DESCRIPTION
## Summary

- replace Black and flake8 with Ruff for formatting and linting
- split Python CI into dedicated quality, test-matrix, and package jobs
- deploy MkDocs through GitHub's official Pages artifact workflow
- publish releases to PyPI through GitHub OIDC trusted publishing
- update README, changelog, installation, testing, contribution, and parser-development guidance

## CI structure

- `quality`: Ruff format and lint checks once on Python 3.12
- `test`: pytest and coverage on Python 3.12, 3.13, and 3.14
- `package`: wheel/sdist builds and installed CLI smoke tests after quality and tests pass

## Deployment security

- Pages deployment permissions are isolated to the deploy job
- PyPI username/password secrets are removed from the workflow
- the PyPI project must have a trusted publisher for `python-publish.yml` and environment `pypi`

## Validation

GitHub Actions will validate Ruff, pytest, packaging, smoke tests, Codecov upload, and the MkDocs build.