### PR TITLE
Preserve mixed element entity blocks

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -50,6 +50,8 @@ semantic versioning.
 - made section parsers validate declared record counts and consume their own
   `$End...` markers
 - made legacy `parse()` and modern `read()` expose the same parser error types
+- made legacy element-block lookup accept an optional element type while
+  retaining two-argument lookup for unambiguous entities
 - exported modern value and collection types at package level while retaining
   `gmshparser.Mesh` as the original compatibility class
 - made visualization helpers accept both the modern `read()` model and the
@@ -70,6 +72,8 @@ semantic versioning.
 
 ### Fixed
 
+- preserved multiple element-type blocks on the same MSH 1.x or 2.x entity
+  instead of overwriting all but the last type
 - removed parser-side failure printing to stdout
 - rejected binary MSH files before attempting to parse ASCII sections
 - reported truncated and malformed records as contextual parser errors instead of

--- a/docs/api/mesh.md
+++ b/docs/api/mesh.md
@@ -28,6 +28,28 @@ The compatibility API is retained for existing applications and for low-level
 parser development. It remains mutable and mirrors the internal MSH entity-block
 structure.
 
+Element blocks are identified by dimension, elementary entity tag, and element
+type. Existing two-argument lookup remains available when an entity contains one
+element type:
+
+```python
+entity = mesh.get_element_entity(2, 1)
+```
+
+For a mixed entity, provide the numeric type or `ElementType` explicitly:
+
+```python
+from gmshparser import ElementType
+
+triangles = mesh.get_element_entity(2, 1, ElementType.TRIANGLE)
+quadrangles = mesh.get_element_entity(2, 1, ElementType.QUADRANGLE)
+```
+
+Calling the two-argument form for a mixed entity raises `KeyError` rather than
+returning an arbitrary block. `has_element_entity()` accepts the same optional
+third argument; without it, the method checks whether any block exists for the
+entity.
+
 Equivalent modern access is considerably flatter:
 
 ```python

--- a/gmshparser/mesh.py
+++ b/gmshparser/mesh.py
@@ -154,22 +154,66 @@ class Mesh:
         """Get element maximum tag."""
         return self.max_element_tag_
 
-    def has_element_entity(self, dim: int, tag: int) -> bool:
-        """Test does mesh have element entity with `(dim, tag)`."""
-        return (dim, tag) in self.element_entities_
+    def has_element_entity(
+        self,
+        dim: int,
+        tag: int,
+        element_type: int | None = None,
+    ) -> bool:
+        """Return whether an element block exists for an entity.
+
+        When ``element_type`` is omitted, this reports whether any element block
+        exists for ``(dim, tag)``. Supplying it checks one exact block.
+        """
+        if element_type is not None:
+            return (dim, tag, int(element_type)) in self.element_entities_
+        return any(
+            entity_dim == dim and entity_tag == tag
+            for entity_dim, entity_tag, _ in self.element_entities_
+        )
 
     def add_element_entity(self, element_entity: ElementEntity):
-        """Add element entity to mesh."""
+        """Add an element block without overwriting other element types."""
         dim = element_entity.get_dimension()
         tag = element_entity.get_tag()
-        self.element_entities_[(dim, tag)] = element_entity
+        element_type = element_entity.get_element_type()
+        self.element_entities_[(dim, tag, element_type)] = element_entity
 
-    def get_element_entity(self, dim: int, tag: int) -> ElementEntity:
-        """Get element entity based on dimension `dim` and tag `tag`."""
-        return self.element_entities_[(dim, tag)]
+    def get_element_entity(
+        self,
+        dim: int,
+        tag: int,
+        element_type: int | None = None,
+    ) -> ElementEntity:
+        """Get one element block by entity and optionally element type.
+
+        The two-argument form is retained for compatibility and succeeds when
+        exactly one element type exists for ``(dim, tag)``. Mixed entities require
+        ``element_type`` to avoid returning an arbitrary block.
+        """
+        if element_type is not None:
+            return self.element_entities_[(dim, tag, int(element_type))]
+
+        matches = [
+            entity
+            for (entity_dim, entity_tag, _), entity in self.element_entities_.items()
+            if entity_dim == dim and entity_tag == tag
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise KeyError((dim, tag))
+
+        available_types = ", ".join(
+            str(entity.get_element_type()) for entity in matches
+        )
+        raise KeyError(
+            f"Element entity ({dim}, {tag}) is ambiguous; provide element_type. "
+            f"Available element types: {available_types}"
+        )
 
     def get_element_entities(self) -> list[ElementEntity]:
-        """Get all element entities as dictionary."""
+        """Get all element blocks in parser order."""
         return self.element_entities_.values()
 
     def set_physical_name(self, dimension: int, tag: int, name: str):

--- a/tests/test_mixed_element_entities.py
+++ b/tests/test_mixed_element_entities.py
@@ -1,0 +1,97 @@
+import pytest
+
+import gmshparser
+import gmshparser.numpy as gnp
+from gmshparser import ElementType
+
+MSH_1_MIXED = """$NOD
+5
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+3 0.0 1.0 0.0
+4 1.0 1.0 0.0
+5 2.0 1.0 0.0
+$ENDNOD
+$ELM
+2
+1 2 99 1 3 1 2 3
+2 3 99 1 4 1 2 4 5
+$ENDELM
+"""
+
+MSH_2_MIXED = """$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+5
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+3 0.0 1.0 0.0
+4 1.0 1.0 0.0
+5 2.0 1.0 0.0
+$EndNodes
+$Elements
+2
+1 2 2 99 1 1 2 3
+2 3 2 99 1 1 2 4 5
+$EndElements
+"""
+
+
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        ("mixed-v1.msh", MSH_1_MIXED),
+        ("mixed-v2.msh", MSH_2_MIXED),
+    ],
+)
+def test_flat_formats_preserve_multiple_element_types_on_one_entity(
+    tmp_path,
+    filename,
+    content,
+):
+    path = tmp_path / filename
+    path.write_text(content)
+
+    legacy = gmshparser.parse(str(path))
+
+    assert legacy.get_number_of_elements() == 2
+    assert legacy.get_number_of_element_entities() == 2
+    assert len(tuple(legacy.get_element_entities())) == 2
+    assert legacy.has_element_entity(2, 1)
+    assert legacy.has_element_entity(2, 1, ElementType.TRIANGLE)
+    assert legacy.has_element_entity(2, 1, ElementType.QUADRANGLE)
+    assert not legacy.has_element_entity(2, 1, ElementType.TETRAHEDRON)
+
+    with pytest.raises(KeyError, match="ambiguous.*element_type"):
+        legacy.get_element_entity(2, 1)
+
+    triangle = legacy.get_element_entity(2, 1, ElementType.TRIANGLE)
+    quadrangle = legacy.get_element_entity(2, 1, ElementType.QUADRANGLE)
+
+    assert triangle.get_element_type() == ElementType.TRIANGLE
+    assert triangle.get_number_of_elements() == 1
+    assert triangle.get_element(1).get_connectivity() == [1, 2, 3]
+    assert quadrangle.get_element_type() == ElementType.QUADRANGLE
+    assert quadrangle.get_number_of_elements() == 1
+    assert quadrangle.get_element(2).get_connectivity() == [1, 2, 4, 5]
+
+    modern = gmshparser.read(path)
+
+    assert modern.elements.tags == (1, 2)
+    assert modern.element_types == frozenset(
+        {ElementType.TRIANGLE, ElementType.QUADRANGLE}
+    )
+    assert modern.entity(2, 1).elements.tags == (1, 2)
+    assert modern.entity(2, 1).element_types == modern.element_types
+
+    arrays = gnp.to_numpy(modern)
+
+    assert set(arrays.element_types) == {
+        ElementType.TRIANGLE,
+        ElementType.QUADRANGLE,
+    }
+    assert arrays.cells[ElementType.TRIANGLE].element_tags.tolist() == [1]
+    assert arrays.cells[ElementType.TRIANGLE].connectivity.tolist() == [[0, 1, 2]]
+    assert arrays.cells[ElementType.QUADRANGLE].element_tags.tolist() == [2]
+    assert arrays.cells[ElementType.QUADRANGLE].connectivity.tolist() == [[0, 1, 3, 4]]


### PR DESCRIPTION
## Summary

- key compatibility-model element blocks by `(dimension, entity_tag, element_type)`
- prevent MSH 1.x and 2.x mixed entities from overwriting earlier element types
- retain two-argument `get_element_entity(dim, tag)` for unambiguous entities
- add optional `element_type` lookup to `get_element_entity()` and `has_element_entity()`
- raise a clear `KeyError` when two-argument lookup is ambiguous
- verify legacy parsing, modern conversion, unified entities, and NumPy cell blocks for mixed triangle/quadrangle entities
- document the compatibility lookup contract and changelog entry
- keep package version at `0.3.1`

## Root cause

The flat-format parsers already grouped records by `(dimension, entity_tag, element_type)`, but `Mesh.add_element_entity()` stored groups using only `(dimension, entity_tag)`. A later element type on the same elementary entity therefore replaced the earlier block.

## Validation

- Ruff formatting and linting: passed
- pytest on Python 3.12, 3.13, and 3.14: passed
- Codecov upload: passed
- wheel and source-distribution builds and smoke tests: passed
- MkDocs build: passed
- final diff contains only the compatibility model, one regression test module, and documentation