### PR TITLE
Add reproducible parser performance baselines

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,79 @@
+name: Parser benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      sizes:
+        description: Comma-separated grid widths
+        required: false
+        default: "32,100,224"
+      repeats:
+        description: Measured subprocess runs per case
+        required: false
+        default: "3"
+      warmups:
+        description: Warm-up subprocess runs per case
+        required: false
+        default: "1"
+  pull_request:
+    branches: [master]
+    paths:
+      - "benchmarks/**"
+      - "gmshparser/**"
+      - "pyproject.toml"
+      - ".github/workflows/benchmarks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Reproducible parser baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+          cache-suffix: benchmarks
+
+      - name: Install benchmark dependencies
+        run: uv sync --no-default-groups --group benchmark
+
+      - name: Run benchmarks
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            sizes="${{ inputs.sizes }}"
+            repeats="${{ inputs.repeats }}"
+            warmups="${{ inputs.warmups }}"
+          else
+            sizes="32,100,224"
+            repeats="2"
+            warmups="1"
+          fi
+
+          uv run --no-sync python -m benchmarks.run \
+            --sizes "$sizes" \
+            --repeats "$repeats" \
+            --warmups "$warmups" \
+            --output benchmark-results.json \
+            --markdown benchmark-summary.md
+
+      - name: Add benchmark job summary
+        run: cat benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: parser-benchmark-results
+          path: |
+            benchmark-results.json
+            benchmark-summary.md
+          if-no-files-found: error

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,10 +29,10 @@ jobs:
         run: uv sync --no-default-groups --group lint
 
       - name: Check formatting
-        run: uv run --no-sync ruff format --check gmshparser tests examples
+        run: uv run --no-sync ruff format --check gmshparser tests examples benchmarks
 
       - name: Lint
-        run: uv run --no-sync ruff check gmshparser tests examples
+        run: uv run --no-sync ruff check gmshparser tests examples benchmarks
 
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible parser benchmark utilities."""

--- a/benchmarks/baselines/2026-07-24-github-ubuntu-python312.json
+++ b/benchmarks/baselines/2026-07-24-github-ubuntu-python312.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "source": "GitHub Actions Parser benchmarks run 30133127529",
+  "generated_at": "2026-07-24T23:13:08.047145+00:00",
+  "environment": {
+    "commit": "0d9d2e487d5539d4c6b00a4ed301d295b6388e22",
+    "python": "3.12.3",
+    "platform": "Linux-6.17.0-1020-azure-x86_64-with-glibc2.39",
+    "gmshparser": "0.3.1",
+    "numpy": "2.5.1"
+  },
+  "settings": {
+    "formats": ["2.2", "4.1"],
+    "sizes": [32, 100, 224],
+    "phases": ["legacy_parse", "legacy_to_modern", "read", "numpy"],
+    "repeats": 2,
+    "warmups": 1
+  },
+  "results": [
+    {"msh_format": "2.2", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 47547, "phase": "legacy_parse", "median_seconds": 0.0618005555, "median_python_peak_bytes": 796490.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "2.2", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 47547, "phase": "legacy_to_modern", "median_seconds": 0.0329304595, "median_python_peak_bytes": 608416.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "2.2", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 47547, "phase": "read", "median_seconds": 0.0957696185, "median_python_peak_bytes": 1380361.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "2.2", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 47547, "phase": "numpy", "median_seconds": 0.023843564, "median_python_peak_bytes": 291836.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "2.2", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 516705, "phase": "legacy_parse", "median_seconds": 0.5890862815, "median_python_peak_bytes": 7559675.0, "median_rss_bytes": 44322816.0},
+    {"msh_format": "2.2", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 516705, "phase": "legacy_to_modern", "median_seconds": 0.315972912, "median_python_peak_bytes": 5609912.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "2.2", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 516705, "phase": "read", "median_seconds": 0.9344808515, "median_python_peak_bytes": 12632555.0, "median_rss_bytes": 52176896.0},
+    {"msh_format": "2.2", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 516705, "phase": "numpy", "median_seconds": 0.146127954, "median_python_peak_bytes": 2756884.0, "median_rss_bytes": 47702016.0},
+    {"msh_format": "2.2", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2905699, "phase": "legacy_parse", "median_seconds": 2.9750446265, "median_python_peak_bytes": 42122932.0, "median_rss_bytes": 151689216.0},
+    {"msh_format": "2.2", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2905699, "phase": "legacy_to_modern", "median_seconds": 1.606452368, "median_python_peak_bytes": 35017120.0, "median_rss_bytes": 114751488.0},
+    {"msh_format": "2.2", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2905699, "phase": "read", "median_seconds": 4.704810505, "median_python_peak_bytes": 73080755.0, "median_rss_bytes": 196771840.0},
+    {"msh_format": "2.2", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2905699, "phase": "numpy", "median_seconds": 0.7407756335, "median_python_peak_bytes": 14982780.0, "median_rss_bytes": 121843712.0},
+    {"msh_format": "4.1", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 39395, "phase": "legacy_parse", "median_seconds": 0.0359851195, "median_python_peak_bytes": 645376.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "4.1", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 39395, "phase": "legacy_to_modern", "median_seconds": 0.0306986075, "median_python_peak_bytes": 481200.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "4.1", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 39395, "phase": "read", "median_seconds": 0.0684118425, "median_python_peak_bytes": 1110253.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "4.1", "cells_per_axis": 32, "number_of_nodes": 1089, "number_of_elements": 1024, "file_size_bytes": 39395, "phase": "numpy", "median_seconds": 0.0239123935, "median_python_peak_bytes": 291836.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "4.1", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 436749, "phase": "legacy_parse", "median_seconds": 0.345178771, "median_python_peak_bytes": 6148558.5, "median_rss_bytes": 41390080.0},
+    {"msh_format": "4.1", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 436749, "phase": "legacy_to_modern", "median_seconds": 0.2917212195, "median_python_peak_bytes": 4330392.0, "median_rss_bytes": 36806656.0},
+    {"msh_format": "4.1", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 436749, "phase": "read", "median_seconds": 0.659880821, "median_python_peak_bytes": 10466711.0, "median_rss_bytes": 48439296.0},
+    {"msh_format": "4.1", "cells_per_axis": 100, "number_of_nodes": 10201, "number_of_elements": 10000, "file_size_bytes": 436749, "phase": "numpy", "median_seconds": 0.145923715, "median_python_peak_bytes": 2756884.0, "median_rss_bytes": 45924352.0},
+    {"msh_format": "4.1", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2504335, "phase": "legacy_parse", "median_seconds": 1.7281375585, "median_python_peak_bytes": 33048942.0, "median_rss_bytes": 134891520.0},
+    {"msh_format": "4.1", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2504335, "phase": "legacy_to_modern", "median_seconds": 1.474976966, "median_python_peak_bytes": 26866864.0, "median_rss_bytes": 98486272.0},
+    {"msh_format": "4.1", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2504335, "phase": "read", "median_seconds": 3.289229436, "median_python_peak_bytes": 59900407.0, "median_rss_bytes": 175970304.0},
+    {"msh_format": "4.1", "cells_per_axis": 224, "number_of_nodes": 50625, "number_of_elements": 50176, "file_size_bytes": 2504335, "phase": "numpy", "median_seconds": 0.74176408, "median_python_peak_bytes": 14982780.0, "median_rss_bytes": 112148480.0}
+  ]
+}

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,412 @@
+"""Generate representative meshes and benchmark the public read paths."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import gmshparser
+from gmshparser.api import Mesh as ModernMesh
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - unavailable on Windows
+    resource = None
+
+PHASES = ("legacy_parse", "legacy_to_modern", "read", "numpy")
+FORMATS = ("2.2", "4.1")
+
+
+def _node_tag(i: int, j: int, width: int) -> int:
+    return j * width + i + 1
+
+
+def _write_msh22(path: Path, cells_per_axis: int) -> tuple[int, int]:
+    width = cells_per_axis + 1
+    number_of_nodes = width * width
+    number_of_elements = cells_per_axis * cells_per_axis
+
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("$MeshFormat\n2.2 0 8\n$EndMeshFormat\n")
+        stream.write(f"$Nodes\n{number_of_nodes}\n")
+        for j in range(width):
+            for i in range(width):
+                tag = _node_tag(i, j, width)
+                stream.write(f"{tag} {float(i)} {float(j)} 0.0\n")
+        stream.write("$EndNodes\n")
+
+        stream.write(f"$Elements\n{number_of_elements}\n")
+        element_tag = 1
+        for j in range(cells_per_axis):
+            for i in range(cells_per_axis):
+                lower_left = _node_tag(i, j, width)
+                lower_right = _node_tag(i + 1, j, width)
+                upper_right = _node_tag(i + 1, j + 1, width)
+                upper_left = _node_tag(i, j + 1, width)
+                stream.write(
+                    f"{element_tag} 3 2 1 1 {lower_left} {lower_right} "
+                    f"{upper_right} {upper_left}\n"
+                )
+                element_tag += 1
+        stream.write("$EndElements\n")
+
+    return number_of_nodes, number_of_elements
+
+
+def _write_msh41(path: Path, cells_per_axis: int) -> tuple[int, int]:
+    width = cells_per_axis + 1
+    number_of_nodes = width * width
+    number_of_elements = cells_per_axis * cells_per_axis
+
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("$MeshFormat\n4.1 0 8\n$EndMeshFormat\n")
+        stream.write(
+            f"$Nodes\n1 {number_of_nodes} 1 {number_of_nodes}\n"
+            f"2 1 0 {number_of_nodes}\n"
+        )
+        for tag in range(1, number_of_nodes + 1):
+            stream.write(f"{tag}\n")
+        for j in range(width):
+            for i in range(width):
+                stream.write(f"{float(i)} {float(j)} 0.0\n")
+        stream.write("$EndNodes\n")
+
+        stream.write(
+            f"$Elements\n1 {number_of_elements} 1 {number_of_elements}\n"
+            f"2 1 3 {number_of_elements}\n"
+        )
+        element_tag = 1
+        for j in range(cells_per_axis):
+            for i in range(cells_per_axis):
+                lower_left = _node_tag(i, j, width)
+                lower_right = _node_tag(i + 1, j, width)
+                upper_right = _node_tag(i + 1, j + 1, width)
+                upper_left = _node_tag(i, j + 1, width)
+                stream.write(
+                    f"{element_tag} {lower_left} {lower_right} "
+                    f"{upper_right} {upper_left}\n"
+                )
+                element_tag += 1
+        stream.write("$EndElements\n")
+
+    return number_of_nodes, number_of_elements
+
+
+def generate_grid(
+    path: Path,
+    msh_format: str,
+    cells_per_axis: int,
+) -> tuple[int, int]:
+    """Write a deterministic quadrilateral grid and return node/element counts."""
+    if cells_per_axis <= 0:
+        raise ValueError("cells_per_axis must be positive")
+    if msh_format == "2.2":
+        return _write_msh22(path, cells_per_axis)
+    if msh_format == "4.1":
+        return _write_msh41(path, cells_per_axis)
+    raise ValueError(f"Unsupported benchmark MSH format: {msh_format}")
+
+
+def _maximum_rss_bytes() -> int | None:
+    if resource is None:
+        return None
+    maximum_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return int(maximum_rss)
+    return int(maximum_rss * 1024)
+
+
+def _result_counts(result: object) -> tuple[int, int]:
+    if hasattr(result, "get_number_of_nodes"):
+        return (
+            int(result.get_number_of_nodes()),
+            int(result.get_number_of_elements()),
+        )
+    if hasattr(result, "number_of_nodes"):
+        return int(result.number_of_nodes), int(result.number_of_elements)
+    if isinstance(result, ModernMesh):
+        return len(result.nodes), len(result.elements)
+    raise TypeError(f"Cannot determine benchmark result counts for {type(result)!r}")
+
+
+def _operation(phase: str, mesh_path: Path) -> Callable[[], object]:
+    if phase == "legacy_parse":
+        return lambda: gmshparser.parse(str(mesh_path))
+
+    if phase == "legacy_to_modern":
+        legacy = gmshparser.parse(str(mesh_path))
+        return lambda: ModernMesh.from_legacy(legacy)
+
+    if phase == "read":
+        return lambda: gmshparser.read(mesh_path)
+
+    if phase == "numpy":
+        import gmshparser.numpy as gnp
+
+        modern = gmshparser.read(mesh_path)
+        return lambda: gnp.to_numpy(modern)
+
+    raise ValueError(f"Unknown benchmark phase: {phase}")
+
+
+def _worker(mesh_path: Path, phase: str) -> dict[str, int | float | None]:
+    operation = _operation(phase, mesh_path)
+    gc.collect()
+    tracemalloc.start()
+    started = time.perf_counter_ns()
+    result = operation()
+    elapsed_ns = time.perf_counter_ns() - started
+    _, python_peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    number_of_nodes, number_of_elements = _result_counts(result)
+
+    return {
+        "seconds": elapsed_ns / 1_000_000_000,
+        "python_peak_bytes": python_peak_bytes,
+        "rss_bytes": _maximum_rss_bytes(),
+        "number_of_nodes": number_of_nodes,
+        "number_of_elements": number_of_elements,
+    }
+
+
+def _run_child(mesh_path: Path, phase: str) -> dict[str, Any]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.run",
+            "--worker",
+            "--mesh",
+            str(mesh_path),
+            "--phase",
+            phase,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError("Benchmark worker produced no JSON output")
+    return json.loads(lines[-1])
+
+
+def _median(values: Sequence[int | float | None]) -> int | float | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return statistics.median(present)
+
+
+def _summarize_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    seconds = [sample["seconds"] for sample in samples]
+    python_peaks = [sample["python_peak_bytes"] for sample in samples]
+    rss_values = [sample["rss_bytes"] for sample in samples]
+    return {
+        "median_seconds": _median(seconds),
+        "minimum_seconds": min(seconds),
+        "maximum_seconds": max(seconds),
+        "median_python_peak_bytes": _median(python_peaks),
+        "median_rss_bytes": _median(rss_values),
+        "samples": samples,
+    }
+
+
+def _format_mebibytes(value: int | float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value / (1024 * 1024):.1f}"
+
+
+def _markdown_report(report: dict[str, Any]) -> str:
+    environment = report["environment"]
+    settings = report["settings"]
+    lines = [
+        "# gmshparser benchmark results",
+        "",
+        f"- Generated: `{report['generated_at']}`",
+        f"- Commit: `{environment['commit']}`",
+        f"- Python: `{environment['python']}`",
+        f"- Platform: `{environment['platform']}`",
+        f"- gmshparser: `{environment['gmshparser']}`",
+        f"- NumPy: `{environment['numpy']}`",
+        f"- Repeats: `{settings['repeats']}` after `{settings['warmups']}` warm-up run(s)",
+        "",
+        "Each measurement runs in a fresh subprocess. `Python peak` is the memory",
+        "allocated during the measured phase according to `tracemalloc`. `Peak RSS`",
+        "is the whole process high-water mark, including prerequisite models retained",
+        "for `legacy_to_modern` and `numpy`.",
+        "",
+        "| MSH | Grid | Nodes | Elements | File MiB | Phase | Median ms | Python peak MiB | Peak RSS MiB |",
+        "| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |",
+    ]
+
+    for result in report["results"]:
+        lines.append(
+            "| "
+            f"{result['msh_format']} | "
+            f"{result['cells_per_axis']}² | "
+            f"{result['number_of_nodes']} | "
+            f"{result['number_of_elements']} | "
+            f"{result['file_size_bytes'] / (1024 * 1024):.2f} | "
+            f"`{result['phase']}` | "
+            f"{result['median_seconds'] * 1000:.2f} | "
+            f"{_format_mebibytes(result['median_python_peak_bytes'])} | "
+            f"{_format_mebibytes(result['median_rss_bytes'])} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "These numbers are a comparison baseline, not a CI performance gate.",
+            "Compare results only when the Python version, machine class, benchmark",
+            "settings, and generated mesh sizes are equivalent.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_csv(value: str) -> list[str]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("Expected at least one comma-separated value")
+    return values
+
+
+def _parent(args: argparse.Namespace) -> int:
+    formats = _parse_csv(args.formats)
+    phases = _parse_csv(args.phases)
+    sizes = [int(value) for value in _parse_csv(args.sizes)]
+
+    unknown_formats = set(formats) - set(FORMATS)
+    unknown_phases = set(phases) - set(PHASES)
+    if unknown_formats:
+        raise ValueError(f"Unsupported formats: {sorted(unknown_formats)}")
+    if unknown_phases:
+        raise ValueError(f"Unsupported phases: {sorted(unknown_phases)}")
+    if any(size <= 0 for size in sizes):
+        raise ValueError("All grid sizes must be positive")
+    if args.repeats <= 0:
+        raise ValueError("repeats must be positive")
+    if args.warmups < 0:
+        raise ValueError("warmups cannot be negative")
+
+    import numpy as np
+
+    temporary_directory: tempfile.TemporaryDirectory[str] | None = None
+    if args.workdir is None:
+        temporary_directory = tempfile.TemporaryDirectory(prefix="gmshparser-bench-")
+        workdir = Path(temporary_directory.name)
+    else:
+        workdir = args.workdir
+        workdir.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict[str, Any]] = []
+    try:
+        for msh_format in formats:
+            for cells_per_axis in sizes:
+                mesh_path = workdir / f"grid-{msh_format}-{cells_per_axis}.msh"
+                number_of_nodes, number_of_elements = generate_grid(
+                    mesh_path,
+                    msh_format,
+                    cells_per_axis,
+                )
+                file_size_bytes = mesh_path.stat().st_size
+
+                for phase in phases:
+                    for _ in range(args.warmups):
+                        _run_child(mesh_path, phase)
+                    samples = [
+                        _run_child(mesh_path, phase) for _ in range(args.repeats)
+                    ]
+                    summary = _summarize_samples(samples)
+                    results.append(
+                        {
+                            "msh_format": msh_format,
+                            "cells_per_axis": cells_per_axis,
+                            "number_of_nodes": number_of_nodes,
+                            "number_of_elements": number_of_elements,
+                            "file_size_bytes": file_size_bytes,
+                            "phase": phase,
+                            **summary,
+                        }
+                    )
+    finally:
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "environment": {
+            "commit": os.environ.get("GITHUB_SHA", "unknown"),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "gmshparser": gmshparser.__version__,
+            "numpy": np.__version__,
+        },
+        "settings": {
+            "formats": formats,
+            "sizes": sizes,
+            "phases": phases,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+        },
+        "results": results,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    markdown = _markdown_report(report)
+    args.markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown.write_text(markdown, encoding="utf-8")
+    print(markdown)
+    return 0
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--formats", default=",".join(FORMATS))
+    parser.add_argument("--sizes", default="32,100,224")
+    parser.add_argument("--phases", default=",".join(PHASES))
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--output", type=Path, default=Path("benchmark-results.json"))
+    parser.add_argument(
+        "--markdown",
+        type=Path,
+        default=Path("benchmark-summary.md"),
+    )
+    parser.add_argument("--workdir", type=Path)
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--mesh", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--phase", choices=PHASES, help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _argument_parser().parse_args(argv)
+    if args.worker:
+        if args.mesh is None or args.phase is None:
+            raise ValueError("Worker mode requires --mesh and --phase")
+        print(json.dumps(_worker(args.mesh, args.phase)))
+        return 0
+    return _parent(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -35,6 +35,10 @@ semantic versioning.
   number, section, and offending line attributes
 - explicit errors for unsupported versions, binary input, unexpected EOF,
   malformed sections, nodes, elements, connectivity, and unknown element types
+- reproducible MSH 2.2 and 4.1 parser benchmarks with elapsed-time, Python
+  allocation, and process RSS reporting for legacy, modern, and NumPy paths
+- a GitHub Actions benchmark workflow that uploads JSON and Markdown reports
+  without enforcing noisy fixed performance thresholds
 - separate Cartesian and parametric node coordinates
 - PEP 621 console-script metadata for the installed `gmshparser` command
 - `gmshparser --version` support
@@ -66,6 +70,7 @@ semantic versioning.
 - replaced Black and flake8 with Ruff for formatting and linting
 - enabled Ruff bugbear, import-sorting, and pyupgrade checks and modernized
   imports, type annotations, string formatting, and loop variables accordingly
+- extended Ruff checks to benchmark sources
 - separated CI into quality, test-matrix, and package jobs
 - replaced the third-party Pages branch publisher with GitHub's official Pages
   artifact and deployment actions

--- a/docs/developer-guide/benchmarks.md
+++ b/docs/developer-guide/benchmarks.md
@@ -1,0 +1,88 @@
+# Performance benchmarks
+
+The repository includes a reproducible benchmark runner for comparing parser
+implementations before and after architectural changes. It generates equivalent
+quadrilateral grids in ASCII MSH 2.2 and 4.1 format, so benchmark inputs do not
+need to be stored in Git or downloaded from external sources.
+
+## Measured phases
+
+The runner measures four public data paths independently:
+
+| Phase | Work measured | Models retained before the phase |
+| --- | --- | --- |
+| `legacy_parse` | `gmshparser.parse(path)` | none |
+| `legacy_to_modern` | `Mesh.from_legacy(legacy)` | parsed compatibility model |
+| `read` | complete `gmshparser.read(path)` | none |
+| `numpy` | `gmshparser.numpy.to_numpy(modern)` | parsed modern model |
+
+This separation shows whether time and memory are spent reading text, building
+the compatibility model, converting to the immutable model, or allocating array
+data.
+
+## Running locally
+
+Install only the benchmark dependencies and run the default matrix:
+
+```bash
+uv sync --no-default-groups --group benchmark
+uv run --no-sync python -m benchmarks.run
+```
+
+The default run uses MSH 2.2 and 4.1 grids with `32²`, `100²`, and `224²`
+elements, three measured subprocesses, and one warm-up subprocess for every
+case. Override any dimension explicitly:
+
+```bash
+uv run --no-sync python -m benchmarks.run \
+  --formats 2.2,4.1 \
+  --sizes 32,100,316 \
+  --phases legacy_parse,legacy_to_modern,read,numpy \
+  --repeats 5 \
+  --warmups 1
+```
+
+The command writes machine-readable `benchmark-results.json` and a rendered
+`benchmark-summary.md`. Use `--workdir PATH` to retain the generated meshes.
+
+## Memory interpretation
+
+Every measured sample runs in a fresh Python subprocess.
+
+- **Python peak** is the allocation high-water mark during the measured phase
+  reported by `tracemalloc`.
+- **Peak RSS** is the operating system's whole-process high-water mark.
+- `legacy_to_modern` RSS includes the compatibility model that must remain alive
+  during conversion.
+- `numpy` RSS includes the modern model that remains alive while arrays are
+  allocated.
+
+Peak RSS is therefore the more useful estimate for application capacity. Python
+peak is useful for locating which phase creates Python-managed objects.
+
+## GitHub Actions
+
+The **Parser benchmarks** workflow runs the default matrix on benchmark-related
+pull requests and uploads both reports as an artifact. It can also be launched
+manually with custom sizes, repetitions, and warm-ups. The workflow verifies
+that benchmarks remain executable but does not compare timings against a fixed
+threshold.
+
+## Comparison rules
+
+Benchmark values are not portable between unrelated machines. Compare two runs
+only when all of these remain equivalent:
+
+- Python and NumPy versions
+- operating system and runner or machine class
+- generated formats and grid sizes
+- phases, repetitions, and warm-up count
+- repository build and dependency configuration
+
+Use median elapsed time for comparisons. Treat small differences on shared CI
+runners as noise and look for consistent changes across multiple sizes.
+
+## Current reference baseline
+
+The first GitHub-hosted reference baseline will be recorded here from the
+benchmark workflow introduced with this page.

--- a/docs/developer-guide/benchmarks.md
+++ b/docs/developer-guide/benchmarks.md
@@ -58,7 +58,9 @@ Every measured sample runs in a fresh Python subprocess.
   allocated.
 
 Peak RSS is therefore the more useful estimate for application capacity. Python
-peak is useful for locating which phase creates Python-managed objects.
+peak is useful for locating which phase creates Python-managed objects. Compare
+RSS values for the same phase across revisions; retained prerequisite models and
+tracing overhead differ between phases.
 
 ## GitHub Actions
 
@@ -84,5 +86,40 @@ runners as noise and look for consistent changes across multiple sizes.
 
 ## Current reference baseline
 
-The first GitHub-hosted reference baseline will be recorded here from the
-benchmark workflow introduced with this page.
+The first reference was produced by GitHub Actions run `30133127529` on
+2026-07-24 using Python 3.12.3, NumPy 2.5.1, Ubuntu/Azure Linux, two measured
+subprocesses, and one warm-up subprocess. The complete median dataset is stored
+in:
+
+```text
+benchmarks/baselines/2026-07-24-github-ubuntu-python312.json
+```
+
+The largest generated case contained 50,625 nodes and 50,176 quadrilateral
+elements:
+
+| MSH | Phase | Median ms | Python peak MiB | Peak RSS MiB |
+| --- | --- | ---: | ---: | ---: |
+| 2.2 | `legacy_parse` | 2,975.04 | 40.2 | 144.7 |
+| 2.2 | `legacy_to_modern` | 1,606.45 | 33.4 | 109.4 |
+| 2.2 | `read` | 4,704.81 | 69.7 | 187.7 |
+| 2.2 | `numpy` | 740.78 | 14.3 | 116.2 |
+| 4.1 | `legacy_parse` | 1,728.14 | 31.5 | 128.6 |
+| 4.1 | `legacy_to_modern` | 1,474.98 | 25.6 | 93.9 |
+| 4.1 | `read` | 3,289.23 | 57.1 | 167.8 |
+| 4.1 | `numpy` | 741.76 | 14.3 | 107.0 |
+
+### Baseline interpretation
+
+- Complete `read()` time scales close to linearly across the 1,024, 10,000, and
+  50,176 element cases.
+- At 50,176 elements, MSH 4.1 completes `read()` about 30% faster than MSH 2.2.
+- Legacy-to-modern conversion accounts for about 34% of MSH 2.2 `read()` time
+  and 45% of MSH 4.1 `read()` time at the largest size.
+- The current complete `read()` path reaches approximately 188 MiB peak RSS for
+  MSH 2.2 and 168 MiB for MSH 4.1 at roughly 50,000 elements.
+
+These values define the comparison point for replacing the legacy intermediate
+model in the modern `read()` path. A successful direct builder should reduce
+`read()` elapsed time and peak RSS without changing the compatibility
+`gmshparser.parse()` path or public mesh contents.

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -31,6 +31,7 @@ Install additional groups only when needed:
 
 ```bash
 uv sync --group docs
+uv sync --group benchmark
 uv sync --group visualization
 uv sync --all-groups
 ```
@@ -48,16 +49,16 @@ git checkout -b feature/your-feature-name
 Run the complete local quality checks:
 
 ```bash
-uv run ruff format --check gmshparser tests examples
-uv run ruff check gmshparser tests examples
+uv run ruff format --check gmshparser tests examples benchmarks
+uv run ruff check gmshparser tests examples benchmarks
 uv run pytest
 ```
 
 Apply formatting and safe automatic lint fixes when necessary:
 
 ```bash
-uv run ruff check --fix gmshparser tests examples
-uv run ruff format gmshparser tests examples
+uv run ruff check --fix gmshparser tests examples benchmarks
+uv run ruff format gmshparser tests examples benchmarks
 ```
 
 Run an individual test:
@@ -72,12 +73,23 @@ Generate an HTML coverage report:
 uv run pytest --cov=gmshparser --cov-report=html
 ```
 
+Run the parser performance baseline:
+
+```bash
+uv sync --no-default-groups --group benchmark
+uv run --no-sync python -m benchmarks.run
+```
+
+See [Performance Benchmarks](benchmarks.md) for the measured phases and valid
+comparison rules.
+
 ## Dependency groups
 
 The groups in `pyproject.toml` have distinct purposes:
 
 | Group | Purpose |
 | --- | --- |
+| `benchmark` | NumPy dependency used by the reproducible benchmark matrix |
 | `test` | pytest and coverage tooling |
 | `lint` | Ruff formatting and linting |
 | `docs` | MkDocs documentation toolchain |
@@ -87,6 +99,7 @@ The groups in `pyproject.toml` have distinct purposes:
 Add dependencies to the narrowest suitable group:
 
 ```bash
+uv add --group benchmark PACKAGE
 uv add --group test PACKAGE
 uv add --group lint PACKAGE
 uv add --group docs PACKAGE
@@ -121,12 +134,14 @@ uv run mkdocs serve
 
 ## Continuous integration
 
-GitHub Actions separates validation into three jobs:
+GitHub Actions separates validation into these workflows and jobs:
 
 - `quality` runs Ruff once on Python 3.12
 - `test` runs pytest on Python 3.12, 3.13, and 3.14
 - `package` builds and smoke-tests the wheel and source distribution after the
   quality and test jobs succeed
+- **Parser benchmarks** records elapsed-time and memory artifacts for
+  benchmark-related pull requests without fixed performance thresholds
 
 Documentation is built on pull requests. Pushes to `master` additionally upload
 and deploy the generated site with GitHub's official Pages actions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Architecture: developer-guide/architecture.md
       - Writing Parsers: developer-guide/writing-parsers.md
       - Testing: developer-guide/testing.md
+      - Performance Benchmarks: developer-guide/benchmarks.md
       - Test Results: developer-guide/test-results.md
   - API Reference:
       - Overview: api/overview.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ Issues = "https://github.com/ahojukka5/gmshparser/issues"
 Repository = "https://github.com/ahojukka5/gmshparser"
 
 [dependency-groups]
+benchmark = [
+    "numpy>=1.26,<3",
+]
 test = [
     "numpy>=1.26,<3",
     "pytest>=8,<10",


### PR DESCRIPTION
## Summary

- add deterministic quadrilateral-grid generators for ASCII MSH 2.2 and 4.1
- benchmark `legacy_parse`, `legacy_to_modern`, complete `read`, and NumPy conversion separately
- run every measured sample in a fresh subprocess
- report median elapsed time, phase-local Python allocations, and whole-process peak RSS
- add machine-readable JSON and rendered Markdown outputs
- add an informational GitHub Actions benchmark workflow with uploaded artifacts
- store the first compact median baseline under `benchmarks/baselines/`
- document local execution, memory interpretation, comparison rules, and baseline findings
- lint benchmark sources in the normal quality job
- keep package version at `0.3.1`

## Design

The workflow does not enforce fixed timing thresholds. It verifies that the benchmark suite remains executable and records comparable artifacts. Performance conclusions must compare equivalent Python versions, machine classes, mesh sizes, and runner settings.

## Reference baseline

GitHub Actions run `30133127529` used Python 3.12.3, NumPy 2.5.1, two measured subprocesses, and one warm-up subprocess.

For 50,176 quadrilateral elements:

| MSH | Phase | Median | Peak RSS |
| --- | --- | ---: | ---: |
| 2.2 | `legacy_parse` | 2.975 s | 144.7 MiB |
| 2.2 | `legacy_to_modern` | 1.606 s | 109.4 MiB |
| 2.2 | `read` | 4.705 s | 187.7 MiB |
| 2.2 | `numpy` | 0.741 s | 116.2 MiB |
| 4.1 | `legacy_parse` | 1.728 s | 128.6 MiB |
| 4.1 | `legacy_to_modern` | 1.475 s | 93.9 MiB |
| 4.1 | `read` | 3.289 s | 167.8 MiB |
| 4.1 | `numpy` | 0.742 s | 107.0 MiB |

Legacy-to-modern conversion accounts for about 34% of MSH 2.2 `read()` time and 45% of MSH 4.1 `read()` time at this size. This is the comparison point for a future direct modern builder.

## Validation

- Ruff formatting and linting: passed
- pytest on Python 3.12, 3.13, and 3.14: passed
- Codecov upload: passed
- wheel and source-distribution builds and smoke tests: passed
- MkDocs build: passed
- benchmark workflow completed successfully twice on the final implementation
- JSON and Markdown benchmark artifacts uploaded successfully
- final diff contains only benchmark infrastructure, one stored baseline, CI configuration, and documentation