### PR TITLE
Validate MSH entity topology

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,16 +28,8 @@ jobs:
       - name: Install quality dependencies
         run: uv sync --no-default-groups --group lint
 
-      - name: Format sources
-        run: uv run --no-sync ruff format gmshparser tests examples benchmarks
-
-      - name: Upload formatted sources
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruff-formatted-sources
-          path: |
-            gmshparser/entities_parser.py
-            tests/test_entities_validation.py
+      - name: Check formatting
+        run: uv run --no-sync ruff format --check gmshparser tests examples benchmarks
 
       - name: Lint
         run: uv run --no-sync ruff check gmshparser tests examples benchmarks

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,8 +28,16 @@ jobs:
       - name: Install quality dependencies
         run: uv sync --no-default-groups --group lint
 
-      - name: Check formatting
-        run: uv run --no-sync ruff format --check gmshparser tests examples benchmarks
+      - name: Format sources
+        run: uv run --no-sync ruff format gmshparser tests examples benchmarks
+
+      - name: Upload formatted sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruff-formatted-sources
+          path: |
+            gmshparser/entities_parser.py
+            tests/test_entities_validation.py
 
       - name: Lint
         run: uv run --no-sync ruff check gmshparser tests examples benchmarks

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -87,6 +87,8 @@ semantic versioning.
 
 - implemented the actual MSH 4.0 `$Entities`, `$Nodes`, `$Elements`, and
   `$Periodic` layouts instead of interpreting those sections as MSH 4.1
+- rejected duplicate MSH 4 entity tags, non-finite or inverted geometry,
+  non-positive physical tags, and references to undeclared boundary entities
 - made `PhysicalGroupCollection.get()` return its default only for missing
   keys while preserving `KeyError` for ambiguous physical-group names
 - preserved multiple element-type blocks on the same MSH 1.x or 2.x entity

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -87,8 +87,8 @@ semantic versioning.
 
 - implemented the actual MSH 4.0 `$Entities`, `$Nodes`, `$Elements`, and
   `$Periodic` layouts instead of interpreting those sections as MSH 4.1
-- rejected duplicate MSH 4 entity tags, non-finite or inverted geometry,
-  non-positive physical tags, and references to undeclared boundary entities
+- rejected duplicate MSH 4 entity tags, non-finite or inverted geometry, and
+  non-positive physical tags
 - made `PhysicalGroupCollection.get()` return its default only for missing
   keys while preserving `KeyError` for ambiguous physical-group names
 - preserved multiple element-type blocks on the same MSH 1.x or 2.x entity

--- a/gmshparser/entities_parser.py
+++ b/gmshparser/entities_parser.py
@@ -75,7 +75,10 @@ class EntitiesParser(AbstractParser):
                 if geometry_count == 6:
                     minimum = geometry[:3]
                     maximum = geometry[3:]
-                    if any(lower > upper for lower, upper in zip(minimum, maximum)):
+                    if any(
+                        lower > upper
+                        for lower, upper in zip(minimum, maximum, strict=True)
+                    ):
                         raise InvalidSectionError(
                             f"Entity {tag} has an inverted bounding box"
                         )

--- a/gmshparser/entities_parser.py
+++ b/gmshparser/entities_parser.py
@@ -151,15 +151,6 @@ class EntitiesParser(AbstractParser):
                             "Entity boundary tags must be non-zero signed integers"
                         )
 
-                    known_boundary_tags = seen_entity_tags[dimension - 1]
-                    for boundary_tag in boundary_tags:
-                        referenced_tag = abs(boundary_tag)
-                        if referenced_tag not in known_boundary_tags:
-                            raise InvalidSectionError(
-                                f"Entity {tag} references unknown dimension-"
-                                f"{dimension - 1} boundary entity {referenced_tag}"
-                            )
-
                 seen_entity_tags[dimension].add(tag)
                 mesh.set_entity_physical_tags(dimension, tag, physical_tags)
 

--- a/gmshparser/entities_parser.py
+++ b/gmshparser/entities_parser.py
@@ -1,3 +1,4 @@
+from math import isfinite
 from typing import TextIO
 
 from .abstract_parser import AbstractParser
@@ -33,6 +34,7 @@ class EntitiesParser(AbstractParser):
             raise InvalidSectionError("$Entities counts cannot be negative")
 
         is_v40 = mesh.get_version_major() == 4 and mesh.get_version_minor() == 0
+        seen_entity_tags: list[set[int]] = [set() for _ in counts]
 
         for dimension, count in enumerate(counts):
             geometry_count = 6 if is_v40 or dimension > 0 else 3
@@ -50,7 +52,9 @@ class EntitiesParser(AbstractParser):
 
                 try:
                     tag = int(parts[0])
-                    _ = tuple(float(value) for value in parts[1:physical_count_index])
+                    geometry = tuple(
+                        float(value) for value in parts[1:physical_count_index]
+                    )
                     number_of_physical_tags = int(parts[physical_count_index])
                 except ValueError as error:
                     raise InvalidSectionError(
@@ -60,6 +64,21 @@ class EntitiesParser(AbstractParser):
 
                 if tag <= 0:
                     raise InvalidSectionError("Entity tags must be positive")
+                if tag in seen_entity_tags[dimension]:
+                    raise InvalidSectionError(
+                        f"Duplicate dimension-{dimension} entity tag {tag}"
+                    )
+                if any(not isfinite(value) for value in geometry):
+                    raise InvalidSectionError(
+                        f"Entity {tag} contains non-finite geometry values"
+                    )
+                if geometry_count == 6:
+                    minimum = geometry[:3]
+                    maximum = geometry[3:]
+                    if any(lower > upper for lower, upper in zip(minimum, maximum)):
+                        raise InvalidSectionError(
+                            f"Entity {tag} has an inverted bounding box"
+                        )
                 if number_of_physical_tags < 0:
                     raise InvalidSectionError(
                         "Entity physical-group counts cannot be negative"
@@ -82,6 +101,10 @@ class EntitiesParser(AbstractParser):
                     raise InvalidSectionError(
                         "Entity physical-group tags must be integers"
                     ) from error
+                if any(physical_tag <= 0 for physical_tag in physical_tags):
+                    raise InvalidSectionError(
+                        "Entity physical-group tags must be positive integers"
+                    )
 
                 if dimension == 0:
                     if len(parts) != physical_stop:
@@ -125,6 +148,16 @@ class EntitiesParser(AbstractParser):
                             "Entity boundary tags must be non-zero signed integers"
                         )
 
+                    known_boundary_tags = seen_entity_tags[dimension - 1]
+                    for boundary_tag in boundary_tags:
+                        referenced_tag = abs(boundary_tag)
+                        if referenced_tag not in known_boundary_tags:
+                            raise InvalidSectionError(
+                                f"Entity {tag} references unknown dimension-"
+                                f"{dimension - 1} boundary entity {referenced_tag}"
+                            )
+
+                seen_entity_tags[dimension].add(tag)
                 mesh.set_entity_physical_tags(dimension, tag, physical_tags)
 
         expect_end_marker(io, "$EndEntities")

--- a/gmshparser/entities_parser.py
+++ b/gmshparser/entities_parser.py
@@ -52,7 +52,9 @@ class EntitiesParser(AbstractParser):
 
                 try:
                     tag = int(parts[0])
-                    geometry = tuple(float(value) for value in parts[1:physical_count_index])
+                    geometry = tuple(
+                        float(value) for value in parts[1:physical_count_index]
+                    )
                     number_of_physical_tags = int(parts[physical_count_index])
                 except ValueError as error:
                     raise InvalidSectionError(
@@ -73,7 +75,10 @@ class EntitiesParser(AbstractParser):
                 if geometry_count == 6:
                     minimum = geometry[:3]
                     maximum = geometry[3:]
-                    if any(lower > upper for lower, upper in zip(minimum, maximum, strict=True)):
+                    if any(
+                        lower > upper
+                        for lower, upper in zip(minimum, maximum, strict=True)
+                    ):
                         raise InvalidSectionError(
                             f"Entity {tag} has an inverted bounding box"
                         )

--- a/gmshparser/entities_parser.py
+++ b/gmshparser/entities_parser.py
@@ -52,9 +52,7 @@ class EntitiesParser(AbstractParser):
 
                 try:
                     tag = int(parts[0])
-                    geometry = tuple(
-                        float(value) for value in parts[1:physical_count_index]
-                    )
+                    geometry = tuple(float(value) for value in parts[1:physical_count_index])
                     number_of_physical_tags = int(parts[physical_count_index])
                 except ValueError as error:
                     raise InvalidSectionError(
@@ -75,10 +73,7 @@ class EntitiesParser(AbstractParser):
                 if geometry_count == 6:
                     minimum = geometry[:3]
                     maximum = geometry[3:]
-                    if any(
-                        lower > upper
-                        for lower, upper in zip(minimum, maximum, strict=True)
-                    ):
+                    if any(lower > upper for lower, upper in zip(minimum, maximum, strict=True)):
                         raise InvalidSectionError(
                             f"Entity {tag} has an inverted bounding box"
                         )

--- a/tests/test_entities_validation.py
+++ b/tests/test_entities_validation.py
@@ -32,11 +32,14 @@ def test_entities_accept_signed_references_to_declared_boundaries():
 
 
 def test_entities_accept_boundaries_declared_in_a_repeated_section():
-    source = _msh41("1 0 0 0\n1 0 0 0 0") + """$Entities
+    source = (
+        _msh41("1 0 0 0\n1 0 0 0 0")
+        + """$Entities
 0 1 0 0
 7 0 0 0 1 0 0 0 1 1
 $EndEntities
 """
+    )
 
     mesh = gmshparser.read(StringIO(source), name="repeated-entities.msh")
 

--- a/tests/test_entities_validation.py
+++ b/tests/test_entities_validation.py
@@ -32,7 +32,7 @@ def test_entities_accept_signed_references_to_declared_boundaries():
 
 
 def test_entities_accept_boundaries_declared_in_a_repeated_section():
-    source = f"""{_msh41('1 0 0 0\n1 0 0 0 0')}$Entities
+    source = _msh41("1 0 0 0\n1 0 0 0 0") + """$Entities
 0 1 0 0
 7 0 0 0 1 0 0 0 1 1
 $EndEntities

--- a/tests/test_entities_validation.py
+++ b/tests/test_entities_validation.py
@@ -31,6 +31,19 @@ def test_entities_accept_signed_references_to_declared_boundaries():
     assert len(mesh.elements) == 0
 
 
+def test_entities_accept_boundaries_declared_in_a_repeated_section():
+    source = f"""{_msh41('1 0 0 0\n1 0 0 0 0')}$Entities
+0 1 0 0
+7 0 0 0 1 0 0 0 1 1
+$EndEntities
+"""
+
+    mesh = gmshparser.read(StringIO(source), name="repeated-entities.msh")
+
+    assert len(mesh.nodes) == 0
+    assert len(mesh.elements) == 0
+
+
 def test_entities_reject_duplicate_tags_within_a_dimension():
     source = _msh41(
         """2 0 0 0
@@ -84,17 +97,3 @@ def test_entities_reject_non_positive_physical_tags():
         match="Entity physical-group tags must be positive integers",
     ):
         gmshparser.read(StringIO(source), name="invalid-physical-tag.msh")
-
-
-def test_entities_reject_unknown_boundary_entities():
-    source = _msh41(
-        """1 1 0 0
-1 0 0 0 0
-7 0 0 0 1 0 0 0 2 1 -2"""
-    )
-
-    with pytest.raises(
-        gmshparser.InvalidSectionError,
-        match="Entity 7 references unknown dimension-0 boundary entity 2",
-    ):
-        gmshparser.read(StringIO(source), name="unknown-boundary.msh")

--- a/tests/test_entities_validation.py
+++ b/tests/test_entities_validation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+import gmshparser
+
+
+def _msh41(entities: str) -> str:
+    return f"""$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+{entities}
+$EndEntities
+"""
+
+
+def test_entities_accept_signed_references_to_declared_boundaries():
+    source = _msh41(
+        """2 1 0 0
+1 0 0 0 0
+2 1 0 0 0
+7 0 0 0 1 0 0 0 2 1 -2"""
+    )
+
+    mesh = gmshparser.read(StringIO(source), name="oriented-boundary.msh")
+
+    assert len(mesh.nodes) == 0
+    assert len(mesh.elements) == 0
+
+
+def test_entities_reject_duplicate_tags_within_a_dimension():
+    source = _msh41(
+        """2 0 0 0
+1 0 0 0 0
+1 1 0 0 0"""
+    )
+
+    with pytest.raises(
+        gmshparser.InvalidSectionError,
+        match="Duplicate dimension-0 entity tag 1",
+    ):
+        gmshparser.read(StringIO(source), name="duplicate-entity.msh")
+
+
+def test_entities_reject_non_finite_geometry_values():
+    source = _msh41(
+        """1 0 0 0
+1 nan 0 0 0"""
+    )
+
+    with pytest.raises(
+        gmshparser.InvalidSectionError,
+        match="Entity 1 contains non-finite geometry values",
+    ):
+        gmshparser.read(StringIO(source), name="non-finite-entity.msh")
+
+
+def test_entities_reject_inverted_bounding_boxes():
+    source = _msh41(
+        """2 1 0 0
+1 0 0 0 0
+2 1 0 0 0
+7 1 0 0 0 0 0 0 2 1 2"""
+    )
+
+    with pytest.raises(
+        gmshparser.InvalidSectionError,
+        match="Entity 7 has an inverted bounding box",
+    ):
+        gmshparser.read(StringIO(source), name="inverted-bounds.msh")
+
+
+def test_entities_reject_non_positive_physical_tags():
+    source = _msh41(
+        """1 0 0 0
+1 0 0 0 1 0"""
+    )
+
+    with pytest.raises(
+        gmshparser.InvalidSectionError,
+        match="Entity physical-group tags must be positive integers",
+    ):
+        gmshparser.read(StringIO(source), name="invalid-physical-tag.msh")
+
+
+def test_entities_reject_unknown_boundary_entities():
+    source = _msh41(
+        """1 1 0 0
+1 0 0 0 0
+7 0 0 0 1 0 0 0 2 1 -2"""
+    )
+
+    with pytest.raises(
+        gmshparser.InvalidSectionError,
+        match="Entity 7 references unknown dimension-0 boundary entity 2",
+    ):
+        gmshparser.read(StringIO(source), name="unknown-boundary.msh")


### PR DESCRIPTION
## Summary

- reject duplicate entity tags within a single `$Entities` section and dimension
- reject non-finite geometry and inverted bounding boxes
- require strictly positive physical-group tags
- preserve signed, oriented boundary references and repeated `$Entities` sections
- add focused regression coverage and document the fix

## Rationale

The parser already validated record lengths and numeric conversion, but discarded geometry after parsing. These checks enforce the MSH tag and geometry invariants without assuming that all entity declarations occur in one section.

## Validation

- Ruff formatting and lint checks
- pytest on Python 3.12, 3.13, and 3.14
- wheel and source-distribution builds and smoke tests
- documentation build
- reproducible parser benchmarks

The package version remains `0.3.1`.