### PR TITLE
ci: run Python CI jobs on the LUMI self-hosted runner

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   quality:
     name: Ruff quality checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lumi, lumi-cpu, lumi-small]
     steps:
       - uses: actions/checkout@v7
 
@@ -36,7 +36,7 @@ jobs:
 
   typing:
     name: Static typing
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lumi, lumi-cpu, lumi-small]
     steps:
       - uses: actions/checkout@v7
 
@@ -60,7 +60,7 @@ jobs:
 
   test:
     name: Test Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lumi, lumi-cpu, lumi-small]
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +95,7 @@ jobs:
 
   package:
     name: Build and smoke-test distributions
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, lumi, lumi-cpu, lumi-small]
     needs: [quality, typing, test]
 
     steps:


### PR DESCRIPTION
Points all four jobs in `python.yml` (`quality`, `typing`, `test`, `package`) at the private LUMI self-hosted runner (labels `[self-hosted, linux, x64, lumi, lumi-cpu, lumi-small]`) instead of `ubuntu-latest`.

No macOS or Docker-service dependencies in this workflow, so all jobs moved over directly.

Part of a batch of PRs adding the LUMI self-hosted runner label across repos; each repo gets its own PR so you can review/merge independently.