### PR TITLE
ci: standardize jobs on self-hosted runners

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,8 +28,9 @@ permissions:
 
 jobs:
   benchmark:
-    name: Reproducible parser baseline
-    runs-on: ubuntu-latest
+    name: bench: reproducible parser baseline
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   benchmark:
-    name: bench: reproducible parser baseline
+    name: "bench: reproducible parser baseline"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,9 @@ concurrency:
 
 jobs:
   build:
-    name: Build documentation
-    runs-on: ubuntu-latest
+    name: docs: build documentation
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -66,9 +67,9 @@ jobs:
           path: ./site
 
   deploy:
-    name: Deploy documentation
+    name: docs: deploy documentation
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     permissions:
       pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: docs: build documentation
+    name: "docs: build documentation"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
@@ -67,7 +67,7 @@ jobs:
           path: ./site
 
   deploy:
-    name: docs: deploy documentation
+    name: "docs: deploy documentation"
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: self-hosted
     needs: build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Verify README-backed homepage
         run: |
-          python - <<'PY'
+          uv run --no-sync python - <<'PY'
           from pathlib import Path
 
           homepage = Path("site/index.html").read_text(encoding="utf-8")

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    name: release: publish to PyPI
+    name: "release: publish to PyPI"
     runs-on: self-hosted
     environment:
       name: pypi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    name: release: publish to PyPI
+    runs-on: self-hosted
     environment:
       name: pypi
       url: https://pypi.org/project/gmshparser/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,24 +10,9 @@ permissions:
   contents: read
 
 jobs:
-  # This repository is public. A pull_request from a fork must never reach
-  # the self-hosted runner used by quality/typing/test/package below --
-  # each needs this job and fails outright (not a silent skip) if the PR's
-  # head repository isn't this same repository, i.e. isn't from someone
-  # with write access.
-  guard-self-hosted:
-    name: Verify trusted source for self-hosted jobs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Reject pull requests from forks
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "::error::Self-hosted runner jobs do not run for pull requests from forks (head repository: ${{ github.event.pull_request.head.repo.full_name }})."
-          exit 1
-
   quality:
-    name: Ruff quality checks
-    needs: guard-self-hosted
+    name: lint: ruff format and check
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
@@ -51,8 +36,8 @@ jobs:
         run: uv run --no-sync ruff check gmshparser tests examples benchmarks
 
   typing:
-    name: Static typing
-    needs: guard-self-hosted
+    name: lint: static typing (mypy)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
@@ -76,8 +61,8 @@ jobs:
         run: uv run --no-sync mypy --strict tests/typing/public_api.py
 
   test:
-    name: Test Python ${{ matrix.python-version }}
-    needs: guard-self-hosted
+    name: test: pytest (python ${{ matrix.python-version }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     strategy:
       fail-fast: false
@@ -112,9 +97,10 @@ jobs:
           fail_ci_if_error: false
 
   package:
-    name: Build and smoke-test distributions
+    name: build: package and smoke-test distributions
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
-    needs: [quality, typing, test, guard-self-hosted]
+    needs: [quality, typing, test]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   quality:
-    name: lint: ruff format and check
+    name: "lint: ruff format and check"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
@@ -36,7 +36,7 @@ jobs:
         run: uv run --no-sync ruff check gmshparser tests examples benchmarks
 
   typing:
-    name: lint: static typing (mypy)
+    name: "lint: static typing (mypy)"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     steps:
@@ -61,7 +61,7 @@ jobs:
         run: uv run --no-sync mypy --strict tests/typing/public_api.py
 
   test:
-    name: test: pytest (python ${{ matrix.python-version }})
+    name: "test: pytest (python ${{ matrix.python-version }})"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     strategy:
@@ -97,7 +97,7 @@ jobs:
           fail_ci_if_error: false
 
   package:
-    name: build: package and smoke-test distributions
+    name: "build: package and smoke-test distributions"
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     needs: [quality, typing, test]


### PR DESCRIPTION
## Summary

- run every GitHub Actions job on the repository's `self-hosted` runner fleet;
- remove the separate hosted fork-guard job and gate PR jobs directly before self-hosted scheduling when the PR head comes from another repository;
- keep documentation, benchmarks, packaging, and PyPI publication on the same self-hosted runner policy;
- align job display names with the portfolio-wide `<category>: <what> (<dims>)` convention.

The repository no longer relies on `ubuntu-latest` or another GitHub-hosted runner label.

Closes #50.