### PR TITLE
ci: cancel superseded runs instead of running every one

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,15 @@ on:
 permissions:
   contents: read
 
+# A newer push or pull-request update makes an in-flight run obsolete. Cancel
+# it instead of letting it run to completion: these jobs land on a shared
+# self-hosted fleet, so a superseded run is holding a slot that current work
+# is queueing for. Grouped per workflow, so unrelated workflows in this
+# repository never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: "lint: ruff format and check"


### PR DESCRIPTION
A newer push or pull-request update makes an in-flight run obsolete, but every one was being left to run to completion.

These jobs run on the shared self-hosted LUMI-K fleet, where dispatch slots are the scarce resource, so a superseded run holds capacity that current work is queueing for. Observed directly: eight runs on one branch within three minutes, every one executed in full.

The group key matches the convention already used in `Oodi.jl/ci.yml`, `Monge.jl/pr.yml` and `cses2026/ci.yml`, scoped per workflow so unrelated workflows in this repository never cancel each other.

Note the controller's own superseded-run cancellation cannot cover this case: it only cancels runs still *queued*, never ones already in progress (deliberately -- real compute is already invested). A workflow-level `concurrency` group is the only thing that stops in-flight work.