### PR TITLE
chore(lint): remove the stale .flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503, F841
-per-file-ignores =
-    __init__.py:F401
-    main_parser.py:F401
-    nodes_parser_v2.py:F401


### PR DESCRIPTION
Closes #56.

Ruff replaced Black and flake8 in 0.4.0, but `.flake8` stayed at the repository root. Nothing reads it — there is no flake8 dependency, `pyproject.toml` configures Ruff, and CI's quality job runs `ruff format --check` and `ruff check` only.

## Impact

None at runtime or in CI. This removes a dead config file whose per-file `F401` ignores were flake8-era suppressions.

## Validation

Run locally against the branch:

- `uv run --no-sync ruff format --check gmshparser tests examples benchmarks` — 61 files already formatted
- `uv run --no-sync ruff check gmshparser tests examples benchmarks` — all checks passed
- `uv run --no-sync pytest -q` — 143 passed, 90% coverage

`ruff check .` (unscoped) reports one pre-existing `I001` in `docs_hooks.py` on both this branch and `master`. CI does not lint the repository root, so it is untouched baseline debt and out of scope here.

The only remaining `flake8` mention is the CHANGELOG 0.4.0 entry recording the migration, which is history and stays.